### PR TITLE
Fixed search of standalone presenter templates so it won't match files with names that cannot be presenter action

### DIFF
--- a/src/LatteTemplateResolver/NetteApplicationUIPresenterStandalone.php
+++ b/src/LatteTemplateResolver/NetteApplicationUIPresenterStandalone.php
@@ -23,8 +23,8 @@ final class NetteApplicationUIPresenterStandalone extends AbstractClassStandalon
         $dir = is_dir("$dir/templates") ? $dir : dirname($dir);
 
         return [
-             $dir . '/templates/' . $presenterName . '/(.*?).latte',
-             $dir . '/templates/' . $presenterName . '\.(.*?).latte',
+             $dir . '/templates/' . $presenterName . '/([a-zA-Z0-9_]*?).latte',
+             $dir . '/templates/' . $presenterName . '\.([a-zA-Z0-9_]?).latte',
         ];
     }
 


### PR DESCRIPTION
it currently matched even filenames taht contained special characters so it cannot be presenter action template