### PR TITLE
LinkProcessor parameters processing fix and fallback to static reflection

### DIFF
--- a/src/Compiler/NodeVisitor/LinkNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/LinkNodeVisitor.php
@@ -109,11 +109,11 @@ final class LinkNodeVisitor extends NodeVisitorAbstract implements PostCompileNo
         try {
             $expressions = $linkProcessor->createLinkExpressions($targetName, $linkParams, $attributes);
         } catch (InvalidPresenterException $e) {
-            return [
-                (new Error($e->getMessage()))
-                    ->setTip('Check if your PHPStan configuration for latte > applicationMapping is correct. See https://github.com/efabrica-team/phpstan-latte#applicationmapping')
-                    ->toNode(),
-            ];
+            $errorNode = (new Error($e->getMessage()))
+                ->setTip('Check if your PHPStan configuration for latte > applicationMapping is correct. See https://github.com/efabrica-team/phpstan-latte#applicationmapping')
+                ->toNode();
+            $errorNode->setAttributes($attributes);
+            return [$errorNode];
         }
         if ($expressions === []) {
             return null;

--- a/src/LinkProcessor/LinkParamsProcessor.php
+++ b/src/LinkProcessor/LinkParamsProcessor.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
-use ReflectionMethod;
+use PHPStan\BetterReflection\BetterReflection;
 
 final class LinkParamsProcessor
 {
@@ -21,38 +21,49 @@ final class LinkParamsProcessor
      */
     public function process(string $class, string $method, array $params): array
     {
-        if ($params === []) {
-            return [];
+        if ($class === '') {
+            throw new InvalidArgumentException('Empty class name');
+        }
+
+        if ($method === '') {
+            throw new InvalidArgumentException('Empty method name');
         }
 
         if (count($params) > 1) {
             throw new InvalidArgumentException('Too many parameters');
         }
 
-        $paramValue = $params[0]->value;
-        if (!$paramValue instanceof Array_) {
-            throw new InvalidArgumentException('Wrong type of parameter value');
-        }
-
         $transferredParams = [];
-        foreach ($paramValue->items as $arrayItem) {
-            if (!$arrayItem instanceof ArrayItem) {
-                continue;
+
+        if ($params !== []) {
+            $paramValue = $params[0]->value;
+            if (!$paramValue instanceof Array_) {
+                throw new InvalidArgumentException('Wrong type of parameter value');
             }
-            $key = $arrayItem->key;
-            if ($key instanceof String_) {  // ignore key for now
-                $arrayItem = new ArrayItem($arrayItem->value, null, $arrayItem->byRef, $arrayItem->getAttributes());
-                $transferredParams[$key->value] = new Arg($arrayItem);
-                continue;
+
+            foreach ($paramValue->items as $arrayItem) {
+                if (!$arrayItem instanceof ArrayItem) {
+                    continue;
+                }
+                $key = $arrayItem->key;
+                if ($key instanceof String_) {  // ignore key for now
+                    $arrayItem = new ArrayItem($arrayItem->value, null, $arrayItem->byRef, $arrayItem->getAttributes());
+                    $transferredParams[$key->value] = new Arg($arrayItem);
+                    continue;
+                }
+                $transferredParams[] = new Arg($arrayItem);
             }
-            $transferredParams[] = new Arg($arrayItem);
         }
 
         $i = 0;
-        $reflectionMethod = new ReflectionMethod($class, $method);
+        $reflectionMethod = (new BetterReflection())->reflector()->reflectClass($class)->getMethod($method);
+        if ($reflectionMethod === null) {
+            throw new InvalidArgumentException("Method $class::$method not found");
+        }
         $methodParameters = [];
         foreach ($reflectionMethod->getParameters() as $param) {
             $name = $param->getName();
+            $type = (string) $param->getType();
             $methodParameters[] = $name;
             if (array_key_exists($i, $transferredParams)) {
                 $transferredParams[$name] = $transferredParams[$i];
@@ -65,6 +76,10 @@ final class LinkParamsProcessor
                     $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue($param->getDefaultValue()));
                 } catch (LogicException $e) {
                 }
+            } elseif ($type === 'array' || $type === 'iterable') {
+                $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue([]));
+            } else {
+                $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue(null));
             }
         }
 

--- a/src/Rule/LatteTemplatesRule.php
+++ b/src/Rule/LatteTemplatesRule.php
@@ -141,7 +141,7 @@ final class LatteTemplatesRule implements Rule
                 $compileFilePath = $this->latteToPhpCompiler->compileFile($actualClass, $templatePath, $template->getVariables(), $template->getComponents());
                 require($compileFilePath); // load type definitions from compiled template
             } catch (Throwable $e) {
-                $errors = array_merge($errors, $this->errorBuilder->buildErrors([new Error($e->getMessage(), $scope->getFile())], $templatePath, $context));
+                $errors = array_merge($errors, $this->errorBuilder->buildErrors([new Error($e->getMessage() ?: get_class($e), $scope->getFile())], $templatePath, $context));
                 continue;
             }
 

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/LinksPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/LinksPresenter.php
@@ -21,4 +21,16 @@ final class LinksPresenter extends ParentPresenter
     public function actionPublish(string $id, int $sorting = 100, bool $isActive = true): void
     {
     }
+
+    public function actionParamsMismatch(string $param1)
+    {
+    }
+
+    public function renderParamsMismatch(string $param1, string $param2)
+    {
+    }
+
+    public function actionArrayParam(array $ids, bool $option = false): void
+    {
+    }
 }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Links/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Links/default.latte
@@ -62,4 +62,21 @@
 <a href="{link publish, isActive => false, id => my-id}">Only publish with switched two arguments as array without [ ] and ' and skipped sorting argument</a>
 <a href="{link Links:publish, isActive => false, id => my-id}">Publish with presenter with switched two arguments as array without [ ] and ' and skipped sorting argument</a>
 
+<a href="{link edit, sorting: 100}">Only edit with named arguments missing required argument</a>
+<a href="{link Links:edit, ['sorting' => 100]}">Only edit with array arguments missing required argument</a>
+<a href="{link Links:edit, sorting => 100}">Only edit with array arguments missing [] missing required argument</a>
+
+<a href="{link edit, sorting: 'str'}">Only edit with named arguments missing required argument</a>
+<a href="{link Links:edit, ['sorting' => 'str']}">Only edit with array arguments missing required argument</a>
+<a href="{link Links:edit, sorting => 'str'}">Only edit with array arguments missing [] missing required argument</a>
+
 <a href="{link Invalid:link}">Invalid link check</a>
+
+<a href="{link Links:paramsMismatch param1 => test}">Invalid link check</a>
+
+<a href="{link Links:arrayParam}">Missing array argument</a>
+<a href="{link Links:arrayParam option: true}">Missing array argument</a>
+<a href="{link Links:arrayParam option => true}">Missing array argument</a>
+<a href="{link Links:arrayParam [1, 2, 3]}">Array argument</a>
+<a href="{link Links:arrayParam option: true, ids: [1, 2, 3]}">Array argument</a>
+<a href="{link Links:arrayParam option => true, ids => [1, 2, 3]}">Array argument</a>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -267,12 +267,12 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
-                'Method ' . LinksPresenter::class . '::actionEdit() invoked with 0 parameters, 1-2 required.',
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, null given.',
                 20,
                 'default.latte',
             ],
             [
-                'Method ' . LinksPresenter::class . '::actionEdit() invoked with 0 parameters, 1-2 required.',
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, null given.',
                 21,
                 'default.latte',
             ],
@@ -317,10 +317,55 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, null given.',
+                65,
+                'default.latte',
+            ],
+            [
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, array<string, int> given.',
+                66,
+                'default.latte',
+            ],
+            [
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, null given.',
+                67,
+                'default.latte',
+            ],
+            [
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, null given.',
+                69,
+                'default.latte',
+            ],
+            [
+                'Parameter #2 $sorting of method ' . LinksPresenter::class . '::actionEdit() expects int, string given.',
+                69,
+                'default.latte',
+            ],
+            [
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, array<string, string> given.',
+                70,
+                'default.latte',
+            ],
+            [
+                'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, null given.',
+                71,
+                'default.latte',
+            ],
+            [
+                'Parameter #2 $sorting of method ' . LinksPresenter::class . '::actionEdit() expects int, string given.',
+                71,
+                'default.latte',
+            ],
+            [
                 'Cannot load presenter \'Links:Invalid\', class \'Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\LinksModule\InvalidPresenter\' was not found.',
-                63,
+                73,
                 'default.latte',
                 'Check if your PHPStan configuration for latte > applicationMapping is correct. See https://github.com/efabrica-team/phpstan-latte#applicationmapping',
+            ],
+            [
+                'Parameter #2 $param2 of method ' . LinksPresenter::class . '::renderParamsMismatch() expects string, null given.',
+                75,
+                'default.latte',
             ],
         ]);
     }


### PR DESCRIPTION
Relying on native autoload of app classes in PHPStan context can lead to false positive link errors 