### PR TITLE
Fix serialization nad PHPDoc generation for complex types

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -49,6 +49,7 @@ services:
     - Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry(%analysedPaths%, %latte.reportUnanalysedTemplates%)
     - Efabrica\PHPStanLatte\Compiler\LatteToPhpCompiler(%latte.tmpDir%)
     - Efabrica\PHPStanLatte\Compiler\LineMapper
+    - Efabrica\PHPStanLatte\Compiler\TypeToPhpDoc
     - Efabrica\PHPStanLatte\LinkProcessor\PresenterFactoryFaker(%latte.applicationMapping%)
 
     # Latte template resolvers
@@ -86,6 +87,7 @@ services:
     - Efabrica\PHPStanLatte\LinkProcessor\LinkParamsProcessor
     - Efabrica\PHPStanLatte\LinkProcessor\PresenterActionLinkProcessor
     - Efabrica\PHPStanLatte\LinkProcessor\SignalLinkProcessor
+
 
     # Collectors
     -

--- a/src/Collector/Finder/ComponentFinder.php
+++ b/src/Collector/Finder/ComponentFinder.php
@@ -10,7 +10,6 @@ use Efabrica\PHPStanLatte\Template\Component;
 use PHPStan\BetterReflection\BetterReflection;
 use PHPStan\BetterReflection\Reflection\ReflectionMethod;
 use PHPStan\Node\CollectedDataNode;
-use PHPStan\PhpDoc\TypeStringResolver;
 
 /**
  * @phpstan-import-type CollectedComponentArray from CollectedComponent
@@ -24,12 +23,9 @@ final class ComponentFinder
 
     private MethodCallFinder $methodCallFinder;
 
-    private TypeStringResolver $typeStringResolver;
-
-    public function __construct(CollectedDataNode $collectedDataNode, MethodCallFinder $methodCallFinder, TypeStringResolver $typeStringResolver)
+    public function __construct(CollectedDataNode $collectedDataNode, MethodCallFinder $methodCallFinder)
     {
         $this->methodCallFinder = $methodCallFinder;
-        $this->typeStringResolver = $typeStringResolver;
 
         $componentsWithTypes = [];
         $collectedComponents = $this->buildData(array_filter(array_merge(...array_values($collectedDataNode->get(ComponentCollector::class)))));
@@ -128,7 +124,7 @@ final class ComponentFinder
         $collectedComponents = [];
         foreach ($data as $itemList) {
             foreach ($itemList as $item) {
-                $collectedComponents[] = CollectedComponent::fromArray($item, $this->typeStringResolver);
+                $collectedComponents[] = CollectedComponent::fromArray($item);
             }
         }
         return $collectedComponents;

--- a/src/Collector/Finder/TemplateRenderFinder.php
+++ b/src/Collector/Finder/TemplateRenderFinder.php
@@ -9,7 +9,6 @@ use Efabrica\PHPStanLatte\Collector\ValueObject\CollectedTemplateRender;
 use Efabrica\PHPStanLatte\Resolver\ValueResolver\PathResolver;
 use PHPStan\BetterReflection\Reflection\ReflectionMethod;
 use PHPStan\Node\CollectedDataNode;
-use PHPStan\PhpDoc\TypeStringResolver;
 
 /**
  * @phpstan-import-type CollectedTemplateRenderArray from CollectedTemplateRender
@@ -27,14 +26,11 @@ final class TemplateRenderFinder
 
     private PathResolver $pathResolver;
 
-    private TypeStringResolver $typeStringResolver;
-
-    public function __construct(CollectedDataNode $collectedDataNode, MethodCallFinder $methodCallFinder, TemplatePathFinder $templatePathFinder, PathResolver $pathResolver, TypeStringResolver $typeStringResolver)
+    public function __construct(CollectedDataNode $collectedDataNode, MethodCallFinder $methodCallFinder, TemplatePathFinder $templatePathFinder, PathResolver $pathResolver)
     {
         $this->methodCallFinder = $methodCallFinder;
         $this->templatePathFinder = $templatePathFinder;
         $this->pathResolver = $pathResolver;
-        $this->typeStringResolver = $typeStringResolver;
 
         $collectedTemplateRenders = $this->buildData(array_filter(array_merge(...array_values($collectedDataNode->get(TemplateRenderCollector::class)))));
         foreach ($collectedTemplateRenders as $collectedTemplateRender) {
@@ -130,7 +126,7 @@ final class TemplateRenderFinder
         $collectedTemplateRenders = [];
         foreach ($data as $itemList) {
             foreach ($itemList as $item) {
-                $collectedTemplateRenders[] = CollectedTemplateRender::fromArray($item, $this->typeStringResolver);
+                $collectedTemplateRenders[] = CollectedTemplateRender::fromArray($item);
             }
         }
         return $collectedTemplateRenders;

--- a/src/Collector/Finder/VariableFinder.php
+++ b/src/Collector/Finder/VariableFinder.php
@@ -10,7 +10,6 @@ use Efabrica\PHPStanLatte\Template\Variable;
 use PHPStan\BetterReflection\BetterReflection;
 use PHPStan\BetterReflection\Reflection\ReflectionMethod;
 use PHPStan\Node\CollectedDataNode;
-use PHPStan\PhpDoc\TypeStringResolver;
 
 /**
  * @phpstan-import-type CollectedVariableArray from CollectedVariable
@@ -24,12 +23,9 @@ final class VariableFinder
 
     private MethodCallFinder $methodCallFinder;
 
-    private TypeStringResolver $typeStringResolver;
-
-    public function __construct(CollectedDataNode $collectedDataNode, MethodCallFinder $methodCallFinder, TypeStringResolver $typeStringResolver)
+    public function __construct(CollectedDataNode $collectedDataNode, MethodCallFinder $methodCallFinder)
     {
         $this->methodCallFinder = $methodCallFinder;
-        $this->typeStringResolver = $typeStringResolver;
 
         $collectedVariables = $this->buildData(array_filter(array_merge(...array_values($collectedDataNode->get(VariableCollector::class)))));
         foreach ($collectedVariables as $collectedVariable) {
@@ -114,7 +110,7 @@ final class VariableFinder
     {
         $collectedVariables = [];
         foreach ($data as $item) {
-            $collectedVariables[] = CollectedVariable::fromArray($item, $this->typeStringResolver);
+            $collectedVariables[] = CollectedVariable::fromArray($item);
         }
         return $collectedVariables;
     }

--- a/src/Collector/TemplateRenderCollector.php
+++ b/src/Collector/TemplateRenderCollector.php
@@ -18,7 +18,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\CollectedData;
 use PHPStan\Collectors\Collector;
-use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ObjectType;
@@ -36,21 +35,17 @@ final class TemplateRenderCollector implements Collector
 
     private PathResolver $pathResolver;
 
-    private TypeStringResolver $typeStringResolver;
-
     private TemplateTypeResolver $templateTypeResolver;
 
     public function __construct(
         NameResolver $nameResolver,
         ValueResolver $valueResolver,
         PathResolver $pathResolver,
-        TypeStringResolver $typeStringResolver,
         TemplateTypeResolver $templateTypeResolver
     ) {
         $this->nameResolver = $nameResolver;
         $this->valueResolver = $valueResolver;
         $this->pathResolver = $pathResolver;
-        $this->typeStringResolver = $typeStringResolver;
         $this->templateTypeResolver = $templateTypeResolver;
     }
 
@@ -232,7 +227,7 @@ final class TemplateRenderCollector implements Collector
             /** @phpstan-var CollectedTemplateRenderArray[] $dataList */
             $dataList = $collectedData->getData();
             foreach ($dataList as $data) {
-                $collectedTemplateRenders[] = CollectedTemplateRender::fromArray($data, $this->typeStringResolver);
+                $collectedTemplateRenders[] = CollectedTemplateRender::fromArray($data);
             }
         }
         return $collectedTemplateRenders;

--- a/src/Collector/ValueObject/CollectedTemplateRender.php
+++ b/src/Collector/ValueObject/CollectedTemplateRender.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Collector\ValueObject;
 
 use Efabrica\PHPStanLatte\Template\Variable;
-use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\ShouldNotHappenException;
 
 /**
- * @phpstan-type CollectedTemplateRenderArray array{templatePath: string|bool|null, variables: array<array{variableName: string, variableType: string}>, className: string, methodName: string, file: string, line: int}
+ * @phpstan-type CollectedTemplateRenderArray array{templatePath: string|bool|null, variables: array<array{name: string, type: string}>, className: string, methodName: string, file: string, line: int}
  */
 final class CollectedTemplateRender
 {
@@ -84,10 +83,7 @@ final class CollectedTemplateRender
     {
         $variables = [];
         foreach ($this->variables as $variable) {
-            $variables[] = [
-                'variableName' => $variable->getName(),
-                'variableType' => $variable->getTypeAsString(),
-            ];
+            $variables[] = $variable->toArray();
         }
         return [
             'templatePath' => $this->templatePath,
@@ -102,11 +98,11 @@ final class CollectedTemplateRender
     /**
      * @phpstan-param CollectedTemplateRenderArray $item
      */
-    public static function fromArray(array $item, TypeStringResolver $typeStringResolver): self
+    public static function fromArray(array $item): self
     {
         $variables = [];
         foreach ($item['variables'] as $variable) {
-            $variables[] = Variable::fromArray($variable, $typeStringResolver);
+            $variables[] = Variable::fromArray($variable);
         }
         if ($item['templatePath'] === true) {
             throw new ShouldNotHappenException('TemplatePath cannot be true, only string, null or false allowed.');

--- a/src/Compiler/LatteToPhpCompiler.php
+++ b/src/Compiler/LatteToPhpCompiler.php
@@ -41,6 +41,8 @@ final class LatteToPhpCompiler
 
     private Standard $printerStandard;
 
+    private TypeToPhpDoc $typeToPhpDoc;
+
     /**
      * @param PostCompileNodeVisitorInterface[] $postCompileNodeVisitors
      */
@@ -49,13 +51,15 @@ final class LatteToPhpCompiler
         CompilerInterface $compiler,
         array $postCompileNodeVisitors,
         LineNumberNodeVisitor $lineNumberNodeVisitor,
-        Standard $printerStandard
+        Standard $printerStandard,
+        TypeToPhpDoc $typeToPhpDoc
     ) {
         $this->tmpDir = $tmpDir ?? sys_get_temp_dir() . '/phpstan-latte';
         $this->compiler = $compiler;
         $this->postCompileNodeVisitors = $postCompileNodeVisitors;
         $this->printerStandard = $printerStandard;
         $this->lineNumberNodeVisitor = $lineNumberNodeVisitor;
+        $this->typeToPhpDoc = $typeToPhpDoc;
     }
 
     /**
@@ -181,11 +185,11 @@ final class LatteToPhpCompiler
 
         $nodeTraverser = new NodeTraverser();
 
-        $addVarTypeNodeVisitor = new AddVarTypesNodeVisitor($variables);
+        $addVarTypeNodeVisitor = new AddVarTypesNodeVisitor($variables, $this->typeToPhpDoc);
         $addVarTypeNodeVisitor->setActualClass($actualClass);
         $nodeTraverser->addVisitor($addVarTypeNodeVisitor);
 
-        $addTypeToComponentNodeVisitor = new AddTypeToComponentNodeVisitor($components);
+        $addTypeToComponentNodeVisitor = new AddTypeToComponentNodeVisitor($components, $this->typeToPhpDoc);
         $nodeTraverser->addVisitor($addTypeToComponentNodeVisitor);
 
         foreach ($this->postCompileNodeVisitors as $postCompileNodeVisitor) {

--- a/src/Compiler/NodeVisitor/AddTypeToComponentNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddTypeToComponentNodeVisitor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor;
 
 use Efabrica\PHPStanLatte\Compiler\LatteVersion;
+use Efabrica\PHPStanLatte\Compiler\TypeToPhpDoc;
 use Efabrica\PHPStanLatte\Error\Error;
 use Efabrica\PHPStanLatte\Template\Component;
 use PhpParser\Comment\Doc;
@@ -33,12 +34,15 @@ final class AddTypeToComponentNodeVisitor extends NodeVisitorAbstract
     /** @var Component[] */
     private array $components;
 
+    private TypeToPhpDoc $typeToPhpDoc;
+
     /**
      * @param Component[] $components
      */
-    public function __construct(array $components)
+    public function __construct(array $components, TypeToPhpDoc $typeToPhpDoc)
     {
         $this->components = $components;
+        $this->typeToPhpDoc = $typeToPhpDoc;
     }
 
     /**
@@ -86,7 +90,7 @@ final class AddTypeToComponentNodeVisitor extends NodeVisitorAbstract
 
         $componentNameParts = explode('-', $componentName);
         $component = $this->findComponentByName($this->components, $componentNameParts);
-        $componentType = $component !== null ? $component->getTypeAsString() : 'mixed';
+        $componentType = $component !== null ? $this->typeToPhpDoc->toPhpDocString($component->getType()) : 'mixed';
         $safeComponentType = $componentType !== 'mixed' ? $componentType : '\Nette\ComponentModel\IComponent';
         $node->setDocComment(new Doc($originalDocCommentText . "\n" . '/** @var ' . $safeComponentType . ' ' . $tmpVarName . ' */'));
 

--- a/src/Compiler/NodeVisitor/AddVarTypesNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddVarTypesNodeVisitor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor;
 
 use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ActualClassNodeVisitorBehavior;
+use Efabrica\PHPStanLatte\Compiler\TypeToPhpDoc;
 use Efabrica\PHPStanLatte\Template\Variable;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
@@ -20,12 +21,15 @@ final class AddVarTypesNodeVisitor extends NodeVisitorAbstract implements PostCo
     /** @var Variable[] */
     private array $variables;
 
+    private TypeToPhpDoc $typeToPhpDoc;
+
     /**
      * @param Variable[] $variables
      */
-    public function __construct(array $variables)
+    public function __construct(array $variables, TypeToPhpDoc $typeToPhpDoc)
     {
         $this->variables = $variables;
+        $this->typeToPhpDoc = $typeToPhpDoc;
     }
 
     public function enterNode(Node $node): ?Node
@@ -51,7 +55,7 @@ final class AddVarTypesNodeVisitor extends NodeVisitorAbstract implements PostCo
         foreach ($combinedVariables as $variable) {
             $prependVarTypesDocBlocks = sprintf(
                 '/** @var %s $%s */',
-                $variable->getTypeAsString(),
+                $this->typeToPhpDoc->toPhpDocString($variable->getType()),
                 $variable->getName()
             );
 

--- a/src/Compiler/TypeToPhpDoc.php
+++ b/src/Compiler/TypeToPhpDoc.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Compiler;
+
+use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use Throwable;
+
+final class TypeToPhpDoc
+{
+    private TypeStringResolver $typeStringResolver;
+
+    public function __construct(TypeStringResolver $typeStringResolver)
+    {
+        $this->typeStringResolver = $typeStringResolver;
+    }
+
+    public function toPhpDocString(Type $type): string
+    {
+        $phpDoc = $type->describe(VerbosityLevel::precise());
+        try {
+            $resolveBack = $this->typeStringResolver->resolve($phpDoc);
+            if ($resolveBack instanceof ErrorType) {
+                $phpDoc = $type->describe(VerbosityLevel::typeOnly());
+            }
+        } catch (Throwable $e) {
+            $phpDoc = $type->describe(VerbosityLevel::typeOnly());
+        }
+        return $phpDoc;
+    }
+}

--- a/src/LatteTemplateResolver/AbstractTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractTemplateResolver.php
@@ -13,13 +13,10 @@ use Efabrica\PHPStanLatte\Collector\Finder\VariableFinder;
 use Efabrica\PHPStanLatte\Collector\ValueObject\CollectedResolvedNode;
 use Efabrica\PHPStanLatte\Resolver\ValueResolver\PathResolver;
 use PHPStan\Node\CollectedDataNode;
-use PHPStan\PhpDoc\TypeStringResolver;
 
 abstract class AbstractTemplateResolver implements LatteTemplateResolverInterface
 {
     private PathResolver $pathResolver;
-
-    private TypeStringResolver $typeStringResolver;
 
     protected MethodCallFinder $methodCallFinder;
 
@@ -33,21 +30,20 @@ abstract class AbstractTemplateResolver implements LatteTemplateResolverInterfac
 
     protected TemplateRenderFinder $templateRenderFinder;
 
-    public function __construct(PathResolver $pathResolver, TypeStringResolver $typeStringResolver)
+    public function __construct(PathResolver $pathResolver)
     {
         $this->pathResolver = $pathResolver;
-        $this->typeStringResolver = $typeStringResolver;
     }
 
     public function resolve(CollectedResolvedNode $resolvedNode, CollectedDataNode $collectedDataNode): LatteTemplateResolverResult
     {
         // TODO create factories?
         $this->methodCallFinder = new MethodCallFinder($collectedDataNode);
-        $this->variableFinder = new VariableFinder($collectedDataNode, $this->methodCallFinder, $this->typeStringResolver);
-        $this->componentFinder = new ComponentFinder($collectedDataNode, $this->methodCallFinder, $this->typeStringResolver);
+        $this->variableFinder = new VariableFinder($collectedDataNode, $this->methodCallFinder);
+        $this->componentFinder = new ComponentFinder($collectedDataNode, $this->methodCallFinder);
         $this->formFinder = new FormFinder($collectedDataNode, $this->methodCallFinder);
         $this->templatePathFinder = new TemplatePathFinder($collectedDataNode, $this->methodCallFinder, $this->pathResolver);
-        $this->templateRenderFinder = new TemplateRenderFinder($collectedDataNode, $this->methodCallFinder, $this->templatePathFinder, $this->pathResolver, $this->typeStringResolver);
+        $this->templateRenderFinder = new TemplateRenderFinder($collectedDataNode, $this->methodCallFinder, $this->templatePathFinder, $this->pathResolver);
 
         return $this->getResult($resolvedNode, $collectedDataNode);
     }

--- a/src/Template/Component.php
+++ b/src/Template/Component.php
@@ -29,6 +29,11 @@ final class Component implements JsonSerializable
         return $this->name;
     }
 
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
     public function getTypeAsString(): string
     {
         return $this->type->describe(VerbosityLevel::typeOnly());
@@ -55,7 +60,7 @@ final class Component implements JsonSerializable
     {
         return [
           'name' => $this->name,
-          'type' => $this->getTypeAsString(),
+          'type' => serialize($this->getType()),
         ];
     }
 }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
@@ -70,6 +70,7 @@ final class CollectorResultForSimpleControlTest extends CollectorResultTest
             'TEMPLATE explicitVars.latte SomeControl::renderExplicitVars ["presenter","control","a","b"] []',
             'TEMPLATE defaultObject.latte SomeControl::renderDefaultObject ["presenter","control","a","b"] []',
             'TEMPLATE explicitObject.latte SomeControl::renderExplicitObject ["presenter","control","a","b"] []',
+            'TEMPLATE complexType.latte SomeControl::renderComplexType ["presenter","control","a","b"] []',
         ]);
     }
 }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/SomeControl.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/SomeControl.php
@@ -47,4 +47,12 @@ final class SomeControl extends Control
         $this->template->setFile(__DIR__ . '/error.latte');
         $this->template->render(__DIR__ . '/explicitObject.latte', new SomeControlTemplateType());
     }
+
+    /**
+     * @param array{"a.b": string, 'b*c'?: int} $param
+     */
+    public function renderComplexType(array $param): void
+    {
+        $this->template->render(__DIR__ . '/complexType.latte', ['a' => $param, 'b' => $param]);
+    }
 }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/complexType.latte
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/complexType.latte
@@ -1,0 +1,3 @@
+{$a}
+{$b}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -184,6 +184,11 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 3,
                 'explicitObject.latte',
             ],
+            [
+                'Variable $nonExistingVariable might not be defined.',
+                3,
+                'complexType.latte',
+            ],
         ]);
     }
 }


### PR DESCRIPTION
Should solve issues described by @jakubvojacek in #105 

Internally types are passed in strings as natively serialized objects (so TypeStrinResolver is not needed in deserialization). When generation PHPDoc representation for compiled template precise form is attempted first. But if it generates invalid PHPDoc (can happen for complex types) then it will fall back to typeOnly.