### PR TITLE
Move nikic/php-parser to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
         "php": ">=7.4 <=8.2",
         "ext-json": "*",
         "phpstan/phpstan": "^1.9.2",
-        "nikic/php-parser": "^4.15",
         "latte/latte": "^2.11.6 | ^3.0.4",
         "nette/utils": "^3.2",
         "nette/finder": "^2.5"
@@ -14,6 +13,7 @@
         "phpunit/phpunit": "^9.5",
         "nette/application": "^3.1.2",
         "nette/forms": "^3.1",
+        "nikic/php-parser": "^4.15",
         "symfony/finder": "^5.4 | ^6.0",
         "efabrica/coding-standard": "^0.4"
     },


### PR DESCRIPTION
Hi, it seems nikic/php-parser is not required for normal operation. only for running tests etc. I think it should be moved.