### PR TITLE
Correct Latte3 extensions config key and value

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Example:
 ```neon
 parameters:
     latte:
-        macros:
-            - MyMacro::install
+        extensions:
+            - MyExtension()
 ```
 
 ### filters

--- a/src/Compiler/Compiler/CompilerFactory.php
+++ b/src/Compiler/Compiler/CompilerFactory.php
@@ -59,7 +59,7 @@ final class CompilerFactory
             }
             return new Latte2Compiler($engine, $this->strictMode, $this->filters, $this->macros);
         } else {
-            if (count($this->extensions) > 0) {
+            if (count($this->macros) > 0) {
                 throw new InvalidArgumentException('You cannot use configuration option latte > macros with Latte 3');
             }
             return new Latte3Compiler($engine, $this->strictMode, $this->filters, $this->extensions);


### PR DESCRIPTION
When trying to set this up with Latte 3, I've noticed the doc config key isn't correct. Eventually went with `engineBootstrap` config but here's what I found. Hope it's useful at least a bit.