### PR TITLE
Dynamic include support and advanced expression resolving for variable values

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -61,6 +61,7 @@ services:
     - Efabrica\PHPStanLatte\LatteTemplateResolver\NetteApplicationUIControl
 
     # Type resolvers
+    - Efabrica\PHPStanLatte\Resolver\TypeResolver\TypeResolver
     - Efabrica\PHPStanLatte\Resolver\TypeResolver\TemplateTypeResolver
 
     # Value resolvers

--- a/src/Collector/VariableCollector.php
+++ b/src/Collector/VariableCollector.php
@@ -7,6 +7,7 @@ namespace Efabrica\PHPStanLatte\Collector;
 use Efabrica\PHPStanLatte\Collector\ValueObject\CollectedVariable;
 use Efabrica\PHPStanLatte\PhpDoc\LattePhpDocResolver;
 use Efabrica\PHPStanLatte\Resolver\TypeResolver\TemplateTypeResolver;
+use Efabrica\PHPStanLatte\Resolver\TypeResolver\TypeResolver;
 use Efabrica\PHPStanLatte\Template\Variable as TemplateVariable;
 use Efabrica\PHPStanLatte\Type\TypeSerializer;
 use PhpParser\Node;
@@ -22,13 +23,16 @@ use PHPStan\Analyser\Scope;
  */
 final class VariableCollector extends AbstractCollector
 {
+    private TypeResolver $typeResolver;
+
     private TemplateTypeResolver $templateTypeResolver;
 
     private LattePhpDocResolver $lattePhpDocResolver;
 
-    public function __construct(TypeSerializer $typeSerializer, TemplateTypeResolver $templateTypeResolver, LattePhpDocResolver $lattePhpDocResolver)
+    public function __construct(TypeSerializer $typeSerializer, TypeResolver $typeResolver, TemplateTypeResolver $templateTypeResolver, LattePhpDocResolver $lattePhpDocResolver)
     {
         parent::__construct($typeSerializer);
+        $this->typeResolver = $typeResolver;
         $this->templateTypeResolver = $templateTypeResolver;
         $this->lattePhpDocResolver = $lattePhpDocResolver;
     }
@@ -82,11 +86,16 @@ final class VariableCollector extends AbstractCollector
             return null;
         }
 
+        $variableType = $this->typeResolver->resolveAsConstantType($node->expr, $scope);
+        if ($variableType === null) {
+            $variableType = $scope->getType($node->expr);
+        }
+
         $variableName = is_string($nameNode) ? $nameNode : $nameNode->name;
         return $this->collectItem(new CollectedVariable(
             $classReflection->getName(),
             $functionName,
-            new TemplateVariable($variableName, $scope->getType($node->expr))
+            new TemplateVariable($variableName, $variableType)
         ));
     }
 }

--- a/src/Resolver/TypeResolver/TypeResolver.php
+++ b/src/Resolver/TypeResolver/TypeResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Resolver\TypeResolver;
+
+use Efabrica\PHPStanLatte\Resolver\ValueResolver\ValueResolver;
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+final class TypeResolver
+{
+    private ValueResolver $valueResolver;
+
+    public function __construct(ValueResolver $valueResolver)
+    {
+        $this->valueResolver = $valueResolver;
+    }
+
+    public function resolveAsConstantType(Expr $expr, Scope $scope): ?Type
+    {
+        $values = $this->valueResolver->resolve($expr, $scope);
+        if ($values === null) {
+            return null;
+        }
+        $types = [];
+        foreach ($values as $value) {
+            if (is_string($value)) {
+                $types[] = new ConstantStringType($value);
+            } elseif (is_int($value)) {
+                $types[] = new ConstantIntegerType($value);
+            } elseif (is_float($value)) {
+                $types[] = new ConstantFloatType($value);
+            } elseif (is_bool($value)) {
+                $types[] = new ConstantBooleanType($value);
+            } elseif (is_null($value)) {
+                $types[] = new NullType();
+            } else {
+                return null; // contains value not convertible to constant type
+            }
+        }
+        return count($types) > 1 ? new UnionType($types) : $types[0];
+    }
+}

--- a/src/Rule/LatteTemplatesRule.php
+++ b/src/Rule/LatteTemplatesRule.php
@@ -163,15 +163,24 @@ final class LatteTemplatesRule implements Rule
             $collectedtemplateRenders = $this->templateRenderCollector->extractCollectedData($fileAnalyserResult->getCollectedData(), $this->typeSerializer, CollectedTemplateRender::class);
             foreach ($collectedtemplateRenders as $collectedTemplateRender) {
                 $includedTemplatePath = $collectedTemplateRender->getTemplatePath();
-                if (is_string($includedTemplatePath)) {
+                if (is_string($includedTemplatePath) && $includedTemplatePath !== '') {
+                    if ($includedTemplatePath[0] !== '/') {
+                        $includedTemplatePath = $dir . '/' . $includedTemplatePath;
+                    }
+                    $includedTemplatePath = realpath($includedTemplatePath) ?: $includedTemplatePath;
                     $includeTemplates[] = new Template(
-                        realpath($dir . '/' . $collectedTemplateRender->getTemplatePath()) ?: '',
+                        $includedTemplatePath,
                         $actualClass,
                         $actualAction,
                         array_merge($collectedTemplateRender->getVariables(), $template->getVariables()),
                         $template->getComponents(),
                         $template->getForms(),
                         $template->getPath()
+                    );
+                } elseif ($includedTemplatePath === '') {
+                    $errors[] = $this->errorBuilder->buildError(
+                        new Error('Empty path to included latte template.', $collectedTemplateRender->getFile(), $collectedTemplateRender->getLine()),
+                        $templatePath
                     );
                 } elseif ($includedTemplatePath === false) {
                     $errors[] = $this->errorBuilder->buildError(

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
@@ -27,6 +27,7 @@ final class CollectorResultForPresenterTest extends CollectorResultTest
             'TEMPLATE parent.latte VariablesPresenter::parent ["startup","startupParent","presenter","control","variableFromParentAction"] ["parentForm","parentDefaultForm"]',
             'TEMPLATE noAction.latte VariablesPresenter:: ["startup","startupParent","presenter","control"] ["parentForm"]',
             'TEMPLATE direct.latte VariablesPresenter::directRender ["startup","startupParent","presenter","control","fromTemplate","fromRender"] ["parentForm"]',
+            'TEMPLATE dynamicInclude.latte VariablesPresenter::dynamicInclude ["startup","startupParent","presenter","control","dynamicIncludeVar","includedTemplate"] ["parentForm"]',
             'NODE NetteApplicationUIPresenter {"className":"ParentPresenter"}',
             'NODE NetteApplicationUIPresenterStandalone {"className":"ParentPresenter"}',
         ], __NAMESPACE__ . '\Fixtures');

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/VariablesPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/VariablesPresenter.php
@@ -48,4 +48,10 @@ final class VariablesPresenter extends ParentPresenter
         $this->template->render(__DIR__ . '/templates/Variables/direct.latte', ['fromRender' => 'b']);
         $this->terminate();
     }
+
+    public function actionDynamicInclude(): void
+    {
+        $this->template->dynamicIncludeVar = 'a';
+        $this->template->includedTemplate = __DIR__ . '/templates/Variables/@includedDynamically.latte';
+    }
 }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/@includedDynamically.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/@includedDynamically.latte
@@ -1,0 +1,2 @@
+{$nonExistingVariable}
+{$dynamicIncludeVar}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/dynamicInclude.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/dynamicInclude.latte
@@ -1,0 +1,3 @@
+{block content}
+{$dynamicIncludeVar}
+{include $includedTemplate}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -138,6 +138,11 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 5,
                 'direct.latte',
             ],
+            [
+                'Variable $nonExistingVariable might not be defined.',
+                1,
+                '@includedDynamically.latte',
+            ],
         ]);
     }
 


### PR DESCRIPTION
Test case for dynamic includes (included path passed in variable).

Not sure how this should be solved. It seems that root cause is that variable type is not passed as constant string but as `literal-string&non-falsy-string`. Maybe just use ValueResolver on variable values in VariableCollector?

---

Implemented. Resolved #141 