### PR TITLE
NetteApplicationUIPresenterCollector to collect presenter specific renders and method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Annotation `@phpstan-latte-ignore` can be used to ignore render calls, variable assignments, component creation, whole methods or classes.
 - Annotation `@phpstan-latte-template` can be used to specify what template is used to render.
 - Annotation `@phpstan-latte-var` can be used to specify what variables are available in tempalte.
-
+- Resolves calls to `setView` and `sendTemplate` in presenters
+ 
 ## [0.2.0] - 2022-12-06
 ### Changed
 - Used collectors to find all variables, components, method calls and templates to analyse

--- a/extension.neon
+++ b/extension.neon
@@ -124,6 +124,7 @@ services:
     - Efabrica\PHPStanLatte\LatteContext\Collector\TemplateRenderMethodPhpDocCollector
     - Efabrica\PHPStanLatte\LatteContext\Collector\FormCollector
     - Efabrica\PHPStanLatte\LatteContext\Collector\RelatedFilesCollector(%analysedPaths%, %latte.collectedPaths%)
+    - Efabrica\PHPStanLatte\LatteContext\Collector\NetteApplicationUIPresenterCollector
 
     # Variable collectors
     variableCollectorStorage:

--- a/src/LatteContext/Collector/MethodOutputCollector.php
+++ b/src/LatteContext/Collector/MethodOutputCollector.php
@@ -59,12 +59,12 @@ final class MethodOutputCollector extends AbstractLatteContextCollector
         $actualClassName = $classReflection->getName();
         $calledClassName = $this->calledClassResolver->resolve($node, $scope);
         $calledMethodName = $this->nameResolver->resolve($node);
-        return [new CollectedMethodCall(
-            $actualClassName,
-            $functionName,
+        return [CollectedMethodCall::build(
+            $node,
+            $scope,
             $calledClassName ?? '',
             $calledMethodName ?? '',
-            CollectedMethodCall::TERMINATING_CALL
+            CollectedMethodCall::OUTPUT_CALL
         )];
     }
 }

--- a/src/LatteContext/Collector/NetteApplicationUIPresenterCollector.php
+++ b/src/LatteContext/Collector/NetteApplicationUIPresenterCollector.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\LatteContext\Collector;
+
+use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedMethodCall;
+use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedTemplateRender;
+use Efabrica\PHPStanLatte\LatteTemplateResolver\NetteApplicationUIPresenter;
+use Efabrica\PHPStanLatte\PhpDoc\LattePhpDocResolver;
+use Efabrica\PHPStanLatte\Resolver\CallResolver\CalledClassResolver;
+use Efabrica\PHPStanLatte\Resolver\NameResolver\NameResolver;
+use Efabrica\PHPStanLatte\Resolver\ValueResolver\ValueResolver;
+use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @extends AbstractLatteContextCollector<CallLike, CollectedTemplateRender|CollectedMethodCall>
+ */
+final class NetteApplicationUIPresenterCollector extends AbstractLatteContextCollector
+{
+    private CalledClassResolver $calledClassResolver;
+
+    private ValueResolver $valueResolver;
+
+    private LattePhpDocResolver $lattePhpDocResolver;
+
+    public function __construct(
+        NameResolver $nameResolver,
+        ReflectionProvider $reflectionProvider,
+        CalledClassResolver $calledClassResolver,
+        ValueResolver $valueResolver,
+        LattePhpDocResolver $lattePhpDocResolver
+    ) {
+        parent::__construct($nameResolver, $reflectionProvider);
+        $this->calledClassResolver = $calledClassResolver;
+        $this->valueResolver = $valueResolver;
+        $this->lattePhpDocResolver = $lattePhpDocResolver;
+    }
+
+    public function getNodeType(): string
+    {
+        return CallLike::class;
+    }
+
+    /**
+     * @param CallLike $node
+     * @phpstan-return null|array<CollectedTemplateRender|CollectedMethodCall>
+     */
+    public function collectData(Node $node, Scope $scope): ?array
+    {
+        $classReflection = $scope->getClassReflection();
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $actualMethodName = $scope->getFunctionName();
+        if ($actualMethodName === null) {
+            return null;
+        }
+
+        if ($this->lattePhpDocResolver->resolveForNode($node, $scope)->isIgnored()) {
+            return null;
+        }
+
+        $actualClassName = $classReflection->getName();
+        $declaringClassName = $this->calledClassResolver->resolveDeclaring($node, $scope);
+        $calledMethodName = $this->nameResolver->resolve($node);
+
+        if ($declaringClassName === null || $calledMethodName === null) {
+            return null;
+        }
+
+        if ((new ObjectType($declaringClassName))->isInstanceOf('Nette\Application\UI\Presenter')->no()) {
+            return null;
+        }
+
+        if (in_array($calledMethodName, ['setView'], true)) {
+            $views = $this->valueResolver->resolve($node->getArgs()[0]->value, $scope);
+            if ($views === null) {
+                return null;
+            }
+            $methodCalls = [];
+            foreach ($views as $view) {
+                if (!is_string($view)) {
+                    continue;
+                }
+                $methodCalls[] = CollectedMethodCall::build(
+                    $node,
+                    $scope,
+                    $declaringClassName,
+                    $calledMethodName,
+                    NetteApplicationUIPresenter::CALL_SET_VIEW,
+                    ['view' => $view]
+                );
+            }
+            return $methodCalls;
+        }
+
+        if (in_array($calledMethodName, ['sendTemplate'], true)) {
+            $argument = $node->getArgs()[0]->value ?? null;
+            if ($argument === null || $scope->getType($argument)->isNull()->maybe()) {
+                return [CollectedTemplateRender::build($node, $scope, null)];
+            } else {
+                // cannot resolve automatically
+                return [CollectedTemplateRender::build($node, $scope, false)];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/LatteContext/Finder/ComponentFinder.php
+++ b/src/LatteContext/Finder/ComponentFinder.php
@@ -102,10 +102,8 @@ final class ComponentFinder
         ];
 
         $methodCalls = $this->methodCallFinder->findCalled($className, $methodName);
-        foreach ($methodCalls as $calledClassName => $calledMethods) {
-            foreach ($calledMethods as $calledMethod) {
-                $collectedComponents[] = $this->findInMethodCalls($calledClassName, $calledMethod, $alreadyFound);
-            }
+        foreach ($methodCalls as $calledMethod) {
+            $collectedComponents[] = $this->findInMethodCalls($calledMethod->getCalledClassName(), $calledMethod->getCalledMethodName(), $alreadyFound);
         }
 
         return array_merge(...$collectedComponents);

--- a/src/LatteContext/Finder/FilterFinder.php
+++ b/src/LatteContext/Finder/FilterFinder.php
@@ -89,10 +89,8 @@ final class FilterFinder
         ];
 
         $methodCalls = $this->methodCallFinder->findCalled($className, $methodName);
-        foreach ($methodCalls as $calledClassName => $calledMethods) {
-            foreach ($calledMethods as $calledMethod) {
-                $collectedFilters[] = $this->findInMethodCalls($calledClassName, $calledMethod, $alreadyFound);
-            }
+        foreach ($methodCalls as $calledMethod) {
+            $collectedFilters[] = $this->findInMethodCalls($calledMethod->getCalledClassName(), $calledMethod->getCalledMethodName(), $alreadyFound);
         }
 
         return array_merge(...$collectedFilters);

--- a/src/LatteContext/Finder/FormFinder.php
+++ b/src/LatteContext/Finder/FormFinder.php
@@ -88,10 +88,8 @@ final class FormFinder
         ];
 
         $methodCalls = $this->methodCallFinder->findCalled($className, $methodName);
-        foreach ($methodCalls as $calledClassName => $calledMethods) {
-            foreach ($calledMethods as $calledMethod) {
-                $collectedForms[] = $this->findInMethodCalls($calledClassName, $calledMethod, $alreadyFound);
-            }
+        foreach ($methodCalls as $calledMethod) {
+            $collectedForms[] = $this->findInMethodCalls($calledMethod->getCalledClassName(), $calledMethod->getCalledMethodName(), $alreadyFound);
         }
 
         return array_merge(...$collectedForms);

--- a/src/LatteContext/Finder/MethodFinder.php
+++ b/src/LatteContext/Finder/MethodFinder.php
@@ -61,10 +61,8 @@ final class MethodFinder
         $alwaysTerminated = $this->find($className, $methodName)->isAlwaysTerminated();
 
         $methodCalls = $this->methodCallFinder->findCalled($className, $methodName);
-        foreach ($methodCalls as $calledClassName => $calledMethods) {
-            foreach ($calledMethods as $calledMethod) {
-                $alwaysTerminated = $alwaysTerminated || $this->findAnyAlwaysTerminatedInMethodCalls($calledClassName, $calledMethod, $alreadyFound);
-            }
+        foreach ($methodCalls as $calledMethod) {
+            $alwaysTerminated = $alwaysTerminated || $this->findAnyAlwaysTerminatedInMethodCalls($calledMethod->getCalledClassName(), $calledMethod->getCalledMethodName(), $alreadyFound);
         }
 
         return $alwaysTerminated;

--- a/src/LatteContext/Finder/TemplatePathFinder.php
+++ b/src/LatteContext/Finder/TemplatePathFinder.php
@@ -99,10 +99,8 @@ final class TemplatePathFinder
         ];
 
         $methodCalls = $this->methodCallFinder->findCalled($className, $methodName);
-        foreach ($methodCalls as $calledClassName => $calledMethods) {
-            foreach ($calledMethods as $calledMethod) {
-                $collectedTemplatePaths[] = $this->findInMethodCalls($calledClassName, $calledMethod, $alreadyFound);
-            }
+        foreach ($methodCalls as $calledMethod) {
+            $collectedTemplatePaths[] = $this->findInMethodCalls($calledMethod->getCalledClassName(), $calledMethod->getCalledMethodName(), $alreadyFound);
         }
 
         return array_merge(...$collectedTemplatePaths);

--- a/src/LatteContext/Finder/TemplateRenderFinder.php
+++ b/src/LatteContext/Finder/TemplateRenderFinder.php
@@ -63,7 +63,7 @@ final class TemplateRenderFinder
         $templateRendersWithTemplatePaths = [];
         foreach ($templateRenders as $templateRender) {
             // when render call does not specify template directly use default template(s) collected from setFile() calls
-            if ($templateRender->getTemplatePath() === null) {
+            if ($templateRender->getTemplatePath() === null && count($defaultTemplatePaths) > 0) {
                 foreach ($defaultTemplatePaths as $defaultTemplatePath) {
                     $templateRendersWithTemplatePaths[] = $templateRender->withTemplatePath($defaultTemplatePath);
                 }
@@ -71,7 +71,6 @@ final class TemplateRenderFinder
                 $templateRendersWithTemplatePaths[] = $templateRender;
             }
         }
-
         return $templateRendersWithTemplatePaths;
     }
 
@@ -100,10 +99,8 @@ final class TemplateRenderFinder
         ];
 
         $methodCalls = $this->methodCallFinder->findCalled($className, $methodName);
-        foreach ($methodCalls as $calledClassName => $calledMethods) {
-            foreach ($calledMethods as $calledMethod) {
-                $collectedTemplateRenders[] = $this->findInMethodCalls($calledClassName, $calledMethod, $alreadyFound);
-            }
+        foreach ($methodCalls as $calledMethod) {
+            $collectedTemplateRenders[] = $this->findInMethodCalls($calledMethod->getCalledClassName(), $calledMethod->getCalledMethodName(), $alreadyFound);
         }
 
         return array_merge(...$collectedTemplateRenders);

--- a/src/LatteContext/Finder/VariableFinder.php
+++ b/src/LatteContext/Finder/VariableFinder.php
@@ -94,10 +94,8 @@ final class VariableFinder
         $collectedVariables = $this->assignedVariables[$className][$methodName] ?? [];
 
         $methodCalls = $this->methodCallFinder->findCalled($className, $methodName);
-        foreach ($methodCalls as $calledClassName => $calledMethods) {
-            foreach ($calledMethods as $calledMethod) {
-                $collectedVariables = VariablesHelper::union($collectedVariables, $this->findInMethodCalls($calledClassName, $calledMethod, $alreadyFound));
-            }
+        foreach ($methodCalls as $calledMethod) {
+            $collectedVariables = VariablesHelper::union($collectedVariables, $this->findInMethodCalls($calledMethod->getCalledClassName(), $calledMethod->getCalledMethodName(), $alreadyFound));
         }
 
         $collectedVariables = VariablesHelper::merge($collectedVariables, $this->declaredVariables[$className][$methodName] ?? []);

--- a/src/LatteTemplateResolver/LatteTemplateResolverResult.php
+++ b/src/LatteTemplateResolver/LatteTemplateResolverResult.php
@@ -77,8 +77,12 @@ final class LatteTemplateResolverResult
     {
         foreach ($templateRenders as $templateRender) {
             $templatePath = $templateRender->getTemplatePath();
-            if (!is_string($templatePath)) {
+            if ($templatePath === false) {
                 $this->addErrorFromBuilder(RuleErrorBuilder::message('Cannot automatically resolve latte template from expression.')
+                    ->file($templateRender->getFile())
+                    ->line($templateRender->getLine()));
+            } elseif ($templatePath === null) {
+                $this->addErrorFromBuilder(RuleErrorBuilder::message("Latte template was not set for $className::$action")
                     ->file($templateRender->getFile())
                     ->line($templateRender->getLine()));
             } else {

--- a/src/LatteTemplateResolver/NetteApplicationUIPresenter.php
+++ b/src/LatteTemplateResolver/NetteApplicationUIPresenter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\LatteTemplateResolver;
 
 use Efabrica\PHPStanLatte\Analyser\LatteContextData;
+use Efabrica\PHPStanLatte\Helper\VariablesHelper;
 use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedForm;
 use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedTemplateRender;
 use Efabrica\PHPStanLatte\Template\Component;
@@ -12,11 +13,17 @@ use Efabrica\PHPStanLatte\Template\Filter;
 use Efabrica\PHPStanLatte\Template\Template;
 use Efabrica\PHPStanLatte\Template\Variable;
 use PHPStan\BetterReflection\Reflection\ReflectionClass;
+use PHPStan\BetterReflection\Reflection\ReflectionMethod;
 use PHPStan\Rules\RuleErrorBuilder;
 
+/**
+ * @phpstan-type ActionDefinition array{variables: Variable[], components: Component[], forms: CollectedForm[], filters: Filter[], line: int, renders: CollectedTemplateRender[], defaultTemplate: ?string, templatePaths: array<?string>, terminated: bool}
+ */
 final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
 {
     use NetteApplicationUIPresenterGlobals;
+
+    public const CALL_SET_VIEW = 'Nette\Application\UI\Presenter::setView';
 
     public function getSupportedClasses(): array
     {
@@ -29,32 +36,56 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
             return new LatteTemplateResolverResult();
         }
 
-        /** @var array<string, array{variables: Variable[], components: Component[], forms: CollectedForm[], filters: Filter[], line: int, renders: CollectedTemplateRender[], templatePaths: array<?string>, terminated: bool}> $actions */
+        /** @var ActionDefinition[] $actions */
         $actions = [];
-        foreach ($this->getMethodsMatching($reflectionClass, '/^(action|render).*/') as $reflectionMethod) {
-            $actionName = lcfirst((string)preg_replace('/^(action|render)/i', '', $reflectionMethod->getName()));
+
+        // action methods - including matching render methods
+        foreach ($this->getMethodsMatching($reflectionClass, '/^action.*/') as $reflectionMethod) {
+            $actionName = lcfirst((string)preg_replace('/^action/i', '', $reflectionMethod->getName()));
 
             if (!isset($actions[$actionName])) {
-                $actions[$actionName] = [
-                    'variables' => $this->getClassGlobalVariables($reflectionClass),
-                    'components' => $this->getClassGlobalComponents($reflectionClass),
-                    'forms' => $this->getClassGlobalForms($reflectionClass),
-                    'filters' => $this->getClassGlobalFilters($reflectionClass),
-                    'line' => $reflectionMethod->getStartLine(),
-                    'renders' => $this->templateRenderFinder->findByMethod($reflectionMethod),
-                    'templatePaths' => $this->templatePathFinder->findByMethod($reflectionMethod),
-                    'terminated' => false,
-                ];
+                $actions[$actionName] = $actions[$actionName] = $this->createActionDefinition($reflectionClass, $actionName);
+            }
+            $this->updateActionDefinitionByMethod($actions[$actionName], $reflectionMethod);
+
+            // alternative renders (changed by setView in startup or action* method)
+            $setViewCalls = array_merge(
+                $this->methodCallFinder->findCalledOfTypeByMethod($reflectionMethod, self::CALL_SET_VIEW),
+                $this->methodCallFinder->findCalledOfType($reflectionClass->getName(), 'startup', self::CALL_SET_VIEW)
+            );
+            $defaultRenderReached = true;
+            foreach ($setViewCalls as $setViewCall) {
+                $view = (string)$setViewCall->getParams()['view'];
+                $actionViewName = $actionName . "($view)";
+                $actions[$actionViewName] = $actions[$actionName];
+                $actions[$actionViewName]['defaultTemplate'] = $this->findDefaultTemplateFilePath($reflectionClass, $view);
+                $renderMethod = $reflectionClass->getMethod('render' . ucfirst($view));
+                if ($renderMethod !== null) {
+                    $this->updateActionDefinitionByMethod($actions[$actionViewName], $renderMethod);
+                }
+                if (!$setViewCall->isCalledConditionally()) {
+                    $defaultRenderReached = false;
+                }
             }
 
-            $actions[$actionName]['variables'] = array_merge($actions[$actionName]['variables'], $this->variableFinder->findByMethod($reflectionMethod));
-            $actions[$actionName]['components'] = array_merge($actions[$actionName]['components'], $this->componentFinder->findByMethod($reflectionMethod));
-            $actions[$actionName]['forms'] = array_merge($actions[$actionName]['forms'], $this->formFinder->findByMethod($reflectionMethod));
-            $actions[$actionName]['filters'] = array_merge($actions[$actionName]['filters'], $this->filterFinder->findByMethod($reflectionMethod));
-            $actions[$actionName]['renders'] = array_merge($actions[$actionName]['renders'], $this->templateRenderFinder->findByMethod($reflectionMethod));
-            $actions[$actionName]['templatePaths'] = array_merge($actions[$actionName]['templatePaths'], $this->templatePathFinder->findByMethod($reflectionMethod));
-            $actions[$actionName]['terminated'] = $actions[$actionName]['terminated'] || $this->methodCallFinder->hasAnyTerminatingCallsByMethod($reflectionMethod);
-            $actions[$actionName]['terminated'] = $actions[$actionName]['terminated'] || $this->methodFinder->hasAnyAlwaysTerminatedByMethod($reflectionMethod);
+            if ($defaultRenderReached) {
+                $renderMethod = $reflectionClass->getMethod('render' . ucfirst($actionName));
+                if ($renderMethod !== null) {
+                    $this->updateActionDefinitionByMethod($actions[$actionName], $renderMethod);
+                }
+            } else {
+                unset($actions[$actionName]); // view is always changed
+            }
+        }
+
+        // render methods without matching action method
+        foreach ($this->getMethodsMatching($reflectionClass, '/^render.*/') as $reflectionMethod) {
+            $actionName = lcfirst((string)preg_replace('/^render/i', '', $reflectionMethod->getName()));
+
+            if (!isset($actions[$actionName])) {
+                $actions[$actionName] = $this->createActionDefinition($reflectionClass, $actionName);
+            }
+            $this->updateActionDefinitionByMethod($actions[$actionName], $reflectionMethod);
         }
 
         $result = new LatteTemplateResolverResult();
@@ -91,8 +122,7 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
             }
 
             // default render with default template
-            $template = $this->findDefaultTemplateFilePath($reflectionClass, $actionName);
-            if ($template === null) {
+            if ($actionDefinition['defaultTemplate'] === null) {
                 if (!$actionDefinition['terminated'] && $actionDefinition['templatePaths'] === []) { // might not be rendered at all (for example redirect or use set template path)
                     $result->addErrorFromBuilder(RuleErrorBuilder::message("Cannot resolve latte template for action $actionName")
                         ->file($reflectionClass->getFileName() ?? 'unknown')
@@ -102,7 +132,7 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
                 continue;
             }
             $result->addTemplate(new Template(
-                $template,
+                $actionDefinition['defaultTemplate'],
                 $reflectionClass->getName(),
                 $actionName,
                 $actionDefinition['variables'],
@@ -113,6 +143,40 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
         }
 
         return $result;
+    }
+
+    /**
+     * @phpstan-return ActionDefinition
+     */
+    private function createActionDefinition(ReflectionClass $reflectionClass, string $actionName): array
+    {
+        return [
+            'variables' => $this->getClassGlobalVariables($reflectionClass),
+            'components' => $this->getClassGlobalComponents($reflectionClass),
+            'forms' => $this->getClassGlobalForms($reflectionClass),
+            'filters' => $this->getClassGlobalFilters($reflectionClass),
+            'line' => -1,
+            'renders' => [],
+            'defaultTemplate' => $this->findDefaultTemplateFilePath($reflectionClass, $actionName),
+            'templatePaths' => [],
+            'terminated' => false,
+        ];
+    }
+
+    /**
+     * @phpstan-param ActionDefinition $actionDefinition
+     */
+    private function updateActionDefinitionByMethod(&$actionDefinition, ReflectionMethod $reflectionMethod): void
+    {
+        $actionDefinition['line'] = $reflectionMethod->getStartLine();
+        $actionDefinition['variables'] = VariablesHelper::union($actionDefinition['variables'], $this->variableFinder->findByMethod($reflectionMethod));
+        $actionDefinition['components'] = array_merge($actionDefinition['components'], $this->componentFinder->findByMethod($reflectionMethod));
+        $actionDefinition['forms'] = array_merge($actionDefinition['forms'], $this->formFinder->findByMethod($reflectionMethod));
+        $actionDefinition['filters'] = array_merge($actionDefinition['filters'], $this->filterFinder->findByMethod($reflectionMethod));
+        $actionDefinition['renders'] = array_merge($actionDefinition['renders'], $this->templateRenderFinder->findByMethod($reflectionMethod));
+        $actionDefinition['templatePaths'] = array_merge($actionDefinition['templatePaths'], $this->templatePathFinder->findByMethod($reflectionMethod));
+        $actionDefinition['terminated'] = $actionDefinition['terminated'] || $this->methodCallFinder->hasAnyTerminatingCallsByMethod($reflectionMethod);
+        $actionDefinition['terminated'] = $actionDefinition['terminated'] || $this->methodFinder->hasAnyAlwaysTerminatedByMethod($reflectionMethod);
     }
 
     private function findDefaultTemplateFilePath(ReflectionClass $reflectionClass, string $actionName): ?string

--- a/src/Resolver/CallResolver/CalledClassResolver.php
+++ b/src/Resolver/CallResolver/CalledClassResolver.php
@@ -10,6 +10,8 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\BetterReflection;
+use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
 
@@ -56,5 +58,32 @@ final class CalledClassResolver
             $callerType = $scope->getType($node->var);
             return $callerType instanceof ObjectType ? $callerType->describe(VerbosityLevel::typeOnly()) : null;
         }
+    }
+
+    public function resolveDeclaring(Node $node, Scope $scope): ?string
+    {
+        if (!$node instanceof MethodCall && !$node instanceof StaticCall) {
+            return null;
+        }
+
+        $calledClassName = $this->resolve($node, $scope);
+        $calledMethodName = $this->nameResolver->resolve($node);
+
+        if ($calledClassName === null || $calledMethodName === null || $calledMethodName === '') {
+            return null;
+        }
+
+        try {
+            $reflectionClass = (new BetterReflection())->reflector()->reflectClass($calledClassName);
+        } catch (IdentifierNotFound $e) {
+            return null;
+        }
+
+        $reflectionMethod = $reflectionClass->getMethod($calledMethodName);
+        if ($reflectionMethod === null) {
+            return null;
+        }
+
+        return $reflectionMethod->getDeclaringClass()->getName();
     }
 }

--- a/src/Resolver/NameResolver/NameResolver.php
+++ b/src/Resolver/NameResolver/NameResolver.php
@@ -24,10 +24,10 @@ final class NameResolver
             return null;
         }
         if (is_string($node)) {
-            return $node;
+            return $node !== '' ? $node : null;
         }
         if ($node instanceof Name || $node instanceof Identifier) {
-            return (string)$node;
+            return $this->resolve((string)$node);
         }
         if ($node instanceof FuncCall || $node instanceof MethodCall || $node instanceof StaticCall) {
             return $this->resolve($node->name);

--- a/tests/Rule/LatteTemplatesRule/Annotations/Fixtures/IgnoredNodes/SomeControl.php
+++ b/tests/Rule/LatteTemplatesRule/Annotations/Fixtures/IgnoredNodes/SomeControl.php
@@ -38,11 +38,11 @@ final class SomeControl extends Control
         $this->template->render(__DIR__ . '/SomeControl.latte');
     }
 
-    // ERROR: Cannot resolve latte template for SomeControl::renderIgnoredTemplatePath().
     public function renderIgnoredTemplatePath()
     {
         /** @phpstan-latte-ignore */
         $this->template->setFile(__DIR__ . '/error.latte');
+        // ERROR: Latte template was not set for SomeControl::renderIgnoredTemplatePath
         $this->template->render();
     }
 

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
@@ -22,12 +22,20 @@ final class CollectorResultForPresenterTest extends CollectorResultTest
         $this->analyse([__DIR__ . '/Fixtures/VariablesPresenter.php', __DIR__ . '/Fixtures/ParentPresenter.php'], [
             'NODE NetteApplicationUIPresenter {"className":"VariablesPresenter"}',
             'NODE NetteApplicationUIPresenterStandalone {"className":"VariablesPresenter"}',
-            'TEMPLATE default.latte VariablesPresenter::default ["startup","startupParent","presenter","control","title","viaGetTemplate","stringLists","localStrings","variableFromParentCalledViaParent","variableFromParent","varFromVariable","variableFromOtherMethod","fromRenderDefault"] ["parentForm","onlyParentDefaultForm"]',
+            'TEMPLATE default.latte VariablesPresenter::default ["startup","startupParent","presenter","control","title","viaGetTemplate","stringLists","localStrings","variableFromParentCalledViaParent","variableFromOtherMethod","variableFromParent","varFromVariable","fromRenderDefault"] ["parentForm","onlyParentDefaultForm"]',
             'TEMPLATE other.latte VariablesPresenter::other ["startup","startupParent","presenter","control","fromOtherAction"] ["parentForm"]',
             'TEMPLATE parent.latte VariablesPresenter::parent ["startup","startupParent","presenter","control","variableFromParentAction"] ["parentForm","parentDefaultForm"]',
             'TEMPLATE noAction.latte VariablesPresenter:: ["startup","startupParent","presenter","control"] ["parentForm"]',
             'TEMPLATE direct.latte VariablesPresenter::directRender ["startup","startupParent","presenter","control","fromTemplate","fromRender"] ["parentForm"]',
             'TEMPLATE dynamicInclude.latte VariablesPresenter::dynamicInclude ["startup","startupParent","presenter","control","dynamicIncludeVar","includedTemplate"] ["parentForm"]',
+            'TEMPLATE onlyRender.latte VariablesPresenter::onlyRender ["startup","startupParent","presenter","control","fromOnlyRender"] ["parentForm"]',
+            'TEMPLATE different.latte VariablesPresenter::different ["startup","startupParent","presenter","control","fromDifferentRender"] ["parentForm"]',
+            'TEMPLATE different2.latte VariablesPresenter::different2 ["startup","startupParent","presenter","control","fromDifferentRender2"] ["parentForm"]',
+            'TEMPLATE different.latte VariablesPresenter::differentRender(different) ["startup","startupParent","presenter","control","fromDifferentRenderAction","fromDifferentRender"] ["parentForm"]',
+            'TEMPLATE different.latte VariablesPresenter::differentRenders(different) ["startup","startupParent","presenter","control","fromDifferentRendersAction","fromDifferentRender"] ["parentForm"]',
+            'TEMPLATE different2.latte VariablesPresenter::differentRenders(different2) ["startup","startupParent","presenter","control","fromDifferentRendersAction","fromDifferentRender2"] ["parentForm"]',
+            'TEMPLATE differentRenderConditional.latte VariablesPresenter::differentRenderConditional ["startup","startupParent","presenter","control"] ["parentForm"]',
+            'TEMPLATE different.latte VariablesPresenter::differentRenderConditional(different) ["startup","startupParent","presenter","control","fromDifferentRender"] ["parentForm"]',
             'NODE NetteApplicationUIPresenter {"className":"ParentPresenter"}',
             'NODE NetteApplicationUIPresenterStandalone {"className":"ParentPresenter"}',
         ], __NAMESPACE__ . '\Fixtures');
@@ -106,6 +114,20 @@ final class CollectorResultForPresenterTest extends CollectorResultTest
             'TEMPLATE throwSometimes.latte ResolvePresenter::throwSometimes ["presenter","control"] []',
             'TEMPLATE recursion.latte ResolvePresenter::recursion ["presenter","control","variableFromRecursionMethod"] []',
             'TEMPLATE setFile.changed.latte ResolvePresenter::setFile ["presenter","control"] []',
+            'TEMPLATE sendTemplate.latte ResolvePresenter::sendTemplate ["presenter","control","send"] []',
+        ]);
+    }
+
+    public function testStartupView(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/StartupViewPresenter.php'], [
+            'NODE NetteApplicationUIPresenter {"className":"StartupViewPresenter"}',
+            'NODE NetteApplicationUIPresenterStandalone {"className":"StartupViewPresenter"}',
+            'TEMPLATE default.latte StartupViewPresenter::default ["startupParent","presenter","control","fromDefault","fromRenderDefault"] ["parentForm"]',
+            'TEMPLATE parent.latte StartupViewPresenter::parent ["startupParent","presenter","control","variableFromParentAction"] ["parentForm","parentDefaultForm"]',
+            'TEMPLATE startup.latte StartupViewPresenter::default(startup) ["startupParent","presenter","control","fromDefault","fromRenderStartup"] ["parentForm"]',
+            'TEMPLATE startup.latte StartupViewPresenter::parent(startup) ["startupParent","presenter","control","variableFromParentAction","fromRenderStartup"] ["parentForm","parentDefaultForm"]',
+            'TEMPLATE startup.latte StartupViewPresenter::startup ["startupParent","presenter","control","fromRenderStartup"] ["parentForm"]',
         ]);
     }
 }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/ResolvePresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/ResolvePresenter.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures;
 
 use Exception;
+use Latte\Engine;
 use Nette\Application\UI\Presenter;
+use Nette\Bridges\ApplicationLatte\DefaultTemplate;
 
 final class ResolvePresenter extends Presenter
 {
@@ -72,5 +74,24 @@ final class ResolvePresenter extends Presenter
     public function actionSetFile(): void
     {
         $this->template->setFile(__DIR__ . '/templates/Resolve/setFile.changed.latte');
+    }
+
+    public function actionSendTemplate(): void
+    {
+        $this->template->send = 'send';
+        $this->template->setFile(__DIR__ . '/templates/Resolve/sendTemplate.latte');
+        $this->sendTemplate();
+    }
+
+    public function actionSendTemplateDefault(): void
+    {
+        $this->template->send = 'send';
+        $this->sendTemplate();
+    }
+
+    public function actionSendTemplateUnresolvable(): void
+    {
+        $this->template->send = 'send';
+        $this->sendTemplate(new DefaultTemplate(new Engine()));
     }
 }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/StartupViewPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/StartupViewPresenter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures;
+
+final class StartupViewPresenter extends ParentPresenter
+{
+    protected function startup()
+    {
+        parent::startup();
+        if ($this->isAjax()) {
+            $this->setView('startup');
+        }
+    }
+
+    public function actionDefault(): void
+    {
+        $this->template->fromDefault = 'default';
+    }
+
+    public function renderDefault(): void
+    {
+        $this->template->fromRenderDefault = 'default';
+    }
+
+    public function renderStartup(): void
+    {
+        $this->template->fromRenderStartup = 'startup';
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/VariablesPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/VariablesPresenter.php
@@ -54,4 +54,38 @@ final class VariablesPresenter extends ParentPresenter
         $this->template->dynamicIncludeVar = 'a';
         $this->template->includedTemplate = __DIR__ . '/templates/Variables/@includedDynamically.latte';
     }
+
+    public function renderOnlyRender(): void
+    {
+        $this->template->fromOnlyRender = 'from only render';
+    }
+
+    public function actionDifferentRender()
+    {
+        $this->template->fromDifferentRenderAction = 'from different render';
+        $this->setView('different');
+    }
+
+    public function actionDifferentRenders(bool $param)
+    {
+        $this->template->fromDifferentRendersAction = 'from different renders';
+        $this->setView($param ? 'different' : 'different2');
+    }
+
+    public function actionDifferentRenderConditional(bool $param)
+    {
+        if ($param) {
+            $this->setView('different');
+        }
+    }
+
+    public function renderDifferent(): void
+    {
+        $this->template->fromDifferentRender = 'from different render 1';
+    }
+
+    public function renderDifferent2(): void
+    {
+        $this->template->fromDifferentRender2 = 'from different render 2';
+    }
 }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Resolve/sendTemplate.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Resolve/sendTemplate.latte
@@ -1,0 +1,3 @@
+{block content}
+
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/StartupView/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/StartupView/default.latte
@@ -1,0 +1,4 @@
+{block content}
+
+{$fromRenderDefault}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/StartupView/parent.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/StartupView/parent.latte
@@ -1,0 +1,4 @@
+{block content}
+
+{$variableFromParentAction}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/StartupView/startup.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/StartupView/startup.latte
@@ -1,0 +1,4 @@
+{block content}
+
+{$fromRenderStartup}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/different.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/different.latte
@@ -1,0 +1,6 @@
+{block content}
+
+{$fromDifferentRenderAction}
+{$fromDifferentRendersAction}
+{$fromDifferentRender}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/different2.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/different2.latte
@@ -1,0 +1,5 @@
+{block content}
+
+{$fromDifferentRendersAction}
+{$fromDifferentRender2}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/differentRenderConditional.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/differentRenderConditional.latte
@@ -1,0 +1,3 @@
+{block content}
+
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/onlyRender.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/onlyRender.latte
@@ -1,0 +1,4 @@
+{block content}
+
+{$fromOnlyRender}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -6,6 +6,7 @@ namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutMo
 
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\LinksPresenter;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\ResolvePresenter;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Source\CustomFormRenderer;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Source\SomeControl;
 
@@ -142,6 +143,81 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'Variable $nonExistingVariable might not be defined.',
                 1,
                 '@includedDynamically.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.',
+                4,
+                'onlyRender.latte',
+            ],
+            [
+                'Variable $fromDifferentRenderAction might not be defined.', // action different
+                3,
+                'different.latte',
+            ],
+            [
+                'Variable $fromDifferentRendersAction might not be defined.', // action different
+                4,
+                'different.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action different
+                6,
+                'different.latte',
+            ],
+            [
+                'Variable $fromDifferentRenderAction might not be defined.', // action differentRenders
+                3,
+                'different.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action differentRenders
+                6,
+                'different.latte',
+            ],
+            [
+                'Variable $fromDifferentRendersAction might not be defined.', // action differentRender
+                4,
+                'different.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action differentRender
+                6,
+                'different.latte',
+            ],
+            [
+                'Variable $fromDifferentRenderAction might not be defined.', // action differentRenderConditional
+                3,
+                'different.latte',
+            ],
+            [
+                'Variable $fromDifferentRendersAction might not be defined.', // action differentRenderConditional
+                4,
+                'different.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action differentRenderConditional
+                6,
+                'different.latte',
+            ],
+            [
+                'Variable $fromDifferentRendersAction might not be defined.', // action different2
+                3,
+                'different2.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action different2
+                5,
+                'different2.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action differentRenders
+                5,
+                'different2.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action differentRenders
+                3,
+                'differentRenderConditional.latte',
             ],
         ]);
     }
@@ -578,6 +654,21 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 3,
                 'setFile.changed.latte',
             ],
+            [
+                'Latte template was not set for ' . ResolvePresenter::class . '::sendTemplateDefault',
+                89,
+                'ResolvePresenter.php',
+            ],
+            [
+                'Cannot automatically resolve latte template from expression.',
+                95,
+                'ResolvePresenter.php',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.',
+                3,
+                'sendTemplate.latte',
+            ],
         ]);
     }
 
@@ -598,6 +689,37 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'Dumped type: array<int>',
                 5,
                 'trait.latte',
+            ],
+        ]);
+    }
+
+    public function testStartupView(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/StartupViewPresenter.php'], [
+            [
+                'Variable $nonExistingVariable might not be defined.', // action default
+                4,
+                'default.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action parent
+                4,
+                'parent.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action startup
+                4,
+                'startup.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action default(startup)
+                4,
+                'startup.latte',
+            ],
+            [
+                'Variable $nonExistingVariable might not be defined.', // action parent(startup)
+                4,
+                'startup.latte',
             ],
         ]);
     }


### PR DESCRIPTION
Resolves #91 
Resolves #102 
Basic implementation of #119 

Summary:
- `CollectedMethodCall` have information if call is performed always (is directly in method body) or sometimes (is nested) - not perfect detection but for basic use cases it is enough - I will try to finde better mechanism later
- `CollectedMethodCall` can optionally store parameters (to be used by resolvers)
- `MethodCallFinder` now returns array of `CollectedMethodCall` instead of just class/method names of called methods to allow use of new information collected for method calls (params, conditionaly/always called)
- New `NetteApplicationUIPresenterCollector` to collect `Presenter` specific renders and method calls for use by `NetteApplicationUIPresenter` resolver
- `sendTemplate` call in `Presenter` is considered as render call
- `NetteApplicationUIPresenter` resolver change of view by calling `setView` in action method

Limitations:
- if setView is called inside condition default view matching action name is also rendered even in cases when setView is called in every brach of condition - I found no way to detect this - may left some false positives
