### PR TITLE
Test case for header variables undefined error

### DIFF
--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/other.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/other.latte
@@ -1,7 +1,10 @@
+{var $headerVar = "something"}
+
 {block content}
 
 {$fromOtherAction}
 {$fromRenderDefault}
 {$nonExistingVariable}
+{$headerVar}
 
 {include @partial.latte, renamedFromOtherAction: $fromOtherAction}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -95,12 +95,12 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
             ],
             [
                 'Variable $fromRenderDefault might not be defined.',
-                4,
+                6,
                 'other.latte',
             ],
             [
                 'Variable $nonExistingVariable might not be defined.',
-                5,
+                7,
                 'other.latte',
             ],
             [

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Variables/SomeControl.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Variables/SomeControl.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\SimpleControl\Fixtures\Variables;
+
+use Nette\Application\UI\Control;
+
+final class SomeControl extends Control
+{
+    public function render(): void
+    {
+        $this->template->a = 'a';
+        $this->template->render(__DIR__ . '/default.latte');
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Variables/default.latte
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Variables/default.latte
@@ -1,0 +1,4 @@
+{var $headerVar = 'something'}
+
+{$nonExistingVariable}
+{$headerVar}

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -277,4 +277,15 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
             ],
         ]);
     }
+
+    public function testVariables(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/Variables/SomeControl.php'], [
+            [
+                'Variable $nonExistingVariable might not be defined.',
+                3,
+                'default.latte',
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
When variable is defined in tempalte header code for variable assignment is placed inside `prepare` method of template. Other methods in template therefore have no idea variable exists during analysis. Pepare method is called before calling odf template to modify content od parameters passed to template.

Not sure how to best solve this. Maybe copy content of prepare method on start of every template method just after parameters var annotations?