### PR TITLE
Use custom parser in postprocessor

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -59,10 +59,7 @@ services:
     - Efabrica\PHPStanLatte\Analyser\FileAnalyserFactory
     - Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry(%analysedPaths%, %latte.reportUnanalysedTemplates%)
     - Efabrica\PHPStanLatte\Compiler\LatteToPhpCompiler(%latte.tmpDir%)
-    -
-        factory: Efabrica\PHPStanLatte\Compiler\Postprocessor
-        arguments:
-            parser: @defaultAnalysisParser
+    - Efabrica\PHPStanLatte\Compiler\Postprocessor
     - Efabrica\PHPStanLatte\Compiler\LineMapper
     - Efabrica\PHPStanLatte\Compiler\TypeToPhpDoc
     - Efabrica\PHPStanLatte\LinkProcessor\PresenterFactoryFaker(%latte.applicationMapping%)


### PR DESCRIPTION
I did not find a reason why use of PHPStan defaultAnalysisPArser do not work in Postprocessor. But I replaced it by custom aprser with parent and nameResolver visitors.