### PR TITLE
Support for links with no mapping

### DIFF
--- a/src/LinkProcessor/PresenterActionLinkProcessor.php
+++ b/src/LinkProcessor/PresenterActionLinkProcessor.php
@@ -57,6 +57,9 @@ final class PresenterActionLinkProcessor implements LinkProcessorInterface
             $presenterClassName = $presenterFactory->getPresenterClass($presenterWithModule);
         } catch (InvalidPresenterException $e) {
             $presenterClassName = $presenterFactory->formatPresenterClass($presenterWithModule);
+            if ($presenterClassName === '') {
+                return [];
+            }
             try {
                 (new BetterReflection())->reflector()->reflectClass($presenterClassName);
             } catch (IdentifierNotFound $notFoundException) {

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
@@ -14,6 +14,7 @@ final class CollectorResultForPresenterTest extends CollectorResultTest
             __DIR__ . '/../../../../rules.neon',
             __DIR__ . '/../../../config.neon',
             __DIR__ . '/config.neon',
+            __DIR__ . '/mapping.neon',
         ];
     }
 

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Links/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Links/default.latte
@@ -80,3 +80,5 @@
 <a href="{link Links:arrayParam [1, 2, 3]}">Array argument</a>
 <a href="{link Links:arrayParam option: true, ids: [1, 2, 3]}">Array argument</a>
 <a href="{link Links:arrayParam option => true, ids => [1, 2, 3]}">Array argument</a>
+
+<a href="{link this}">Link to this</a>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -19,6 +19,7 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
             __DIR__ . '/../../../../rules.neon',
             __DIR__ . '/../../../config.neon',
             __DIR__ . '/config.neon',
+            __DIR__ . '/mapping.neon',
         ];
     }
 

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterWithNoMappingTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterWithNoMappingTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule;
+
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+
+final class LatteTemplatesRuleForPresenterWithNoMappingTest extends LatteTemplatesRuleTest
+{
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../../../../rules.neon',
+            __DIR__ . '/../../../config.neon',
+            __DIR__ . '/config.neon',
+        ];
+    }
+
+    public function testLinks(): void
+    {
+        // Without mapping no links are created, so no errors are found
+        $this->analyse([__DIR__ . '/Fixtures/LinksPresenter.php'], []);
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/config.neon
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/config.neon
@@ -5,8 +5,6 @@ parameters:
             closureFilter: 'Closure(string, int): string'
             closureWithSlashFilter: '\Closure(string, int): string'
             callableFilter: 'callable(string, int): string'
-        applicationMapping:
-            *: Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\*Presenter
         collectedPaths:
             - tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures
             - tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Source

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/mapping.neon
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/mapping.neon
@@ -1,0 +1,4 @@
+parameters:
+    latte:
+        applicationMapping:
+            *: Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\*Presenter


### PR DESCRIPTION
If mapping is not set, we should not throw exception `Invalid identifier name ""` just keep compiled template as is.