### PR TITLE
Improving finders with multiple method names in one call

### DIFF
--- a/src/LatteContext/Finder/ComponentFinder.php
+++ b/src/LatteContext/Finder/ComponentFinder.php
@@ -62,13 +62,16 @@ final class ComponentFinder
     /**
      * @return Component[]
      */
-    public function find(string $className, string $methodName): array
+    public function find(string $className, string ...$methodNames): array
     {
-        return ComponentsHelper::merge(
+        $foundComponents = [
             $this->findInClasses($className),
             $this->findInMethodCalls($className, '__construct'),
-            $this->findInMethodCalls($className, $methodName),
-        );
+        ];
+        foreach ($methodNames as $methodName) {
+            $foundComponents[] = $this->findInMethodCalls($className, $methodName);
+        }
+        return ComponentsHelper::merge(...$foundComponents);
     }
 
     /**

--- a/src/LatteContext/Finder/FilterFinder.php
+++ b/src/LatteContext/Finder/FilterFinder.php
@@ -36,14 +36,18 @@ final class FilterFinder
     /**
      * @return Filter[]
      */
-    public function find(string $className, string $methodName): array
+    public function find(string $className, string ...$methodNames): array
     {
-        return array_merge(
+        $foundFilters = [
             $this->collectedFilters[$className][''] ?? [],
             $this->findInParents($className),
             $this->findInMethodCalls($className, '__construct'),
-            $this->findInMethodCalls($className, $methodName),
-        );
+        ];
+        foreach ($methodNames as $methodName) {
+            $foundFilters[] = $this->findInMethodCalls($className, $methodName);
+        }
+
+        return array_merge(...$foundFilters);
     }
 
     /**

--- a/src/LatteContext/Finder/FormFieldFinder.php
+++ b/src/LatteContext/Finder/FormFieldFinder.php
@@ -37,13 +37,16 @@ final class FormFieldFinder
     /**
      * @return FormField[]
      */
-    public function find(string $className, string $methodName): array
+    public function find(string $className, string ...$methodNames): array
     {
-        return FormFieldHelper::merge(
+        $foundFormFields = [
             $this->findInClasses($className),
             $this->findInMethodCalls($className, '__construct'),
-            $this->findInMethodCalls($className, $methodName),
-        );
+        ];
+        foreach ($methodNames as $methodName) {
+            $foundFormFields[] = $this->findInMethodCalls($className, $methodName);
+        }
+        return FormFieldHelper::merge(...$foundFormFields);
     }
 
     /**

--- a/src/LatteContext/Finder/FormFinder.php
+++ b/src/LatteContext/Finder/FormFinder.php
@@ -39,14 +39,17 @@ final class FormFinder
     /**
      * @return Form[]
      */
-    public function find(string $className, string $methodName): array
+    public function find(string $className, string ...$methodNames): array
     {
-        /** @var CollectedForm[] $collectedForms */
-        $collectedForms = array_merge(
+        $foundForms = [
             $this->findInClasses($className),
             $this->findInMethodCalls($className, '__construct'),
-            $this->findInMethodCalls($className, $methodName),
-        );
+        ];
+        foreach ($methodNames as $methodName) {
+            $foundForms[] = $this->findInMethodCalls($className, $methodName);
+        }
+        /** @var CollectedForm[] $collectedForms */
+        $collectedForms = array_merge(...$foundForms);
 
         $forms = [];
         foreach ($collectedForms as $collectedForm) {

--- a/src/LatteContext/Finder/TemplatePathFinder.php
+++ b/src/LatteContext/Finder/TemplatePathFinder.php
@@ -46,14 +46,17 @@ final class TemplatePathFinder
     /**
      * @return array<?string>
      */
-    public function find(string $className, string $methodName): array
+    public function find(string $className, string ...$methodNames): array
     {
-        return array_merge(
+        $foundTemplatePaths = [
             $this->collectedTemplatePaths[$className][''] ?? [],
             $this->findInParents($className),
             $this->findInMethodCalls($className, '__construct'),
-            $this->findInMethodCalls($className, $methodName),
-        );
+        ];
+        foreach ($methodNames as $methodName) {
+            $foundTemplatePaths[] = $this->findInMethodCalls($className, $methodName);
+        }
+        return array_merge(...$foundTemplatePaths);
     }
 
     /**

--- a/src/LatteContext/Finder/VariableFinder.php
+++ b/src/LatteContext/Finder/VariableFinder.php
@@ -43,13 +43,16 @@ final class VariableFinder
     /**
      * @return Variable[]
      */
-    public function find(string $className, string $methodName): array
+    public function find(string $className, string ...$methodNames): array
     {
-        return VariablesHelper::merge(
+        $foundVariables = [
             $this->findInClasses($className),
             $this->findInMethodCalls($className, '__construct'),
-            $this->findInMethodCalls($className, $methodName)
-        );
+        ];
+        foreach ($methodNames as $methodName) {
+            $foundVariables[] = $this->findInMethodCalls($className, $methodName);
+        }
+        return VariablesHelper::merge(...$foundVariables);
     }
 
     /**

--- a/src/LatteTemplateResolver/NetteApplicationUIPresenterGlobals.php
+++ b/src/LatteTemplateResolver/NetteApplicationUIPresenterGlobals.php
@@ -13,8 +13,7 @@ trait NetteApplicationUIPresenterGlobals
         $className = $reflectionClass->getName();
         $presenterType = new ObjectType($reflectionClass->getName());
         return array_merge(
-            $this->variableFinder->find($className, 'startup'),
-            $this->variableFinder->find($className, 'beforeRender'),
+            $this->variableFinder->find($className, 'startup', 'beforeRender'),
             [
                 new Variable('presenter', $presenterType),
                 new Variable('control', $presenterType),
@@ -25,30 +24,18 @@ trait NetteApplicationUIPresenterGlobals
     protected function getClassGlobalComponents(ReflectionClass $reflectionClass): array
     {
         $className = $reflectionClass->getName();
-        return array_merge(
-            $this->componentFinder->find($className, ''),
-            $this->componentFinder->find($className, 'startup'),
-            $this->componentFinder->find($className, 'beforeRender')
-        );
+        return $this->componentFinder->find($className, 'startup', 'beforeRender');
     }
 
     protected function getClassGlobalForms(ReflectionClass $reflectionClass): array
     {
         $className = $reflectionClass->getName();
-        return array_merge(
-            $this->formFinder->find($className, ''),
-            $this->formFinder->find($className, 'startup'),
-            $this->formFinder->find($className, 'beforeRender')
-        );
+        return $this->formFinder->find($className, 'startup', 'beforeRender');
     }
 
     protected function getClassGlobalFilters(ReflectionClass $reflectionClass): array
     {
         $className = $reflectionClass->getName();
-        return array_merge(
-            $this->filterFinder->find($className, ''),
-            $this->filterFinder->find($className, 'startup'),
-            $this->filterFinder->find($className, 'beforeRender')
-        );
+        return $this->filterFinder->find($className, 'startup', 'beforeRender');
     }
 }


### PR DESCRIPTION
This begins as hot fix for collecting variables from methods which are overrided in traits (or parents), but it is also optimisation because some methods are called just once e.g. 
```
$this->findInClasses($className)
```
and
```
$this->findInMethodCalls($className, '__construct')
```
in VariableFinder from NetteApplicationUIPresenterGlobals