### PR TITLE
AbstractClassStandaloneTemplateResolver - fixed support for overwritting getClassGlobal* methods

### DIFF
--- a/src/LatteTemplateResolver/AbstractClassStandaloneTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractClassStandaloneTemplateResolver.php
@@ -15,16 +15,15 @@ abstract class AbstractClassStandaloneTemplateResolver extends AbstractClassTemp
     {
         $result = new LatteTemplateResolverResult();
         $standaloneTemplateFiles = $this->findStandaloneTemplates($reflectionClass);
-        $classContextResolver = $this->getClassContextResolver($reflectionClass, $latteContext);
         foreach ($standaloneTemplateFiles as $standaloneTemplateFile) {
             $result->addTemplate(new Template(
                 $standaloneTemplateFile,
                 $reflectionClass->getName(),
                 null,
-                $classContextResolver->getVariables(),
-                $classContextResolver->getComponents(),
-                $classContextResolver->getForms(),
-                $classContextResolver->getFilters()
+                $this->getClassGlobalVariables($reflectionClass, $latteContext),
+                $this->getClassGlobalComponents($reflectionClass, $latteContext),
+                $this->getClassGlobalForms($reflectionClass, $latteContext),
+                $this->getClassGlobalFilters($reflectionClass, $latteContext)
             ));
         }
         return $result;


### PR DESCRIPTION
In some of our custom resolver I use overrdiing of getClassGlobalVariables - it was broken for standalone resolvers