### PR TITLE
export-ignore unneeded files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.gitattributes export-ignore
+.github export-ignore
+.gitignore export-ignore
+Makefile export-ignore
+phpstan.neon export-ignore
+phpunit.xml export-ignore
+tests/ export-ignore


### PR DESCRIPTION
These files are not needed for the operation of the extension, so they don't need to be in the distribution package. Removing these cuts the total number of files to half.