### PR TITLE
Template cache key dependencies

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -69,7 +69,7 @@ services:
 
     - Efabrica\PHPStanLatte\Analyser\FileAnalyserFactory
     - Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry(%analysedPaths%, %latte.reportUnanalysedTemplates%)
-    - Efabrica\PHPStanLatte\Compiler\LatteToPhpCompiler(%latte.tmpDir%)
+    - Efabrica\PHPStanLatte\Compiler\LatteToPhpCompiler(%latte.tmpDir%, ::md5(::json_encode(%latte%)))
 
     -
         factory: Efabrica\PHPStanLatte\Compiler\Postprocessor


### PR DESCRIPTION
Fixes overwriting of compiled templates

Cache Key now include
- extension config
- PHP version
- Latte version
- instaled composer packages versions (if composer autolaoder is used)