### PR TITLE
Block parameters fix

### DIFF
--- a/src/Compiler/NodeVisitor/RenderBlockNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/RenderBlockNodeVisitor.php
@@ -10,9 +10,9 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\BinaryOp\Plus;
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
@@ -135,7 +135,7 @@ final class RenderBlockNodeVisitor extends NodeVisitorAbstract
                 continue;
             }
             $variableName = $this->nameResolver->resolve($blockMethodParam->var->name);
-            $methodCallArgs[] = new Arg($params[$pos] ?? $params[$variableName] ?? new ConstFetch(new Name('null')));
+            $methodCallArgs[] = new Arg($params[$pos] ?? $params[$variableName] ?? new New_(new Name('MissingBlockParameter')));
         }
 
         return new MethodCall(new Variable('this'), $blockMethodName, $methodCallArgs);

--- a/src/Error/ErrorBuilder.php
+++ b/src/Error/ErrorBuilder.php
@@ -36,6 +36,7 @@ final class ErrorBuilder
         '/Parameter #3 \$s of static method Latte\\\\Runtime\\\\Filters::convertTo\(\) expects string, mixed given\./',   // latte 3 internal error
         '/Cannot call method addAttributes\(\) on Nette\\\\Utils\\\\Html\|string\./',
         '/Method Nette\\\\Forms\\\\Controls\\\\BaseControl::getControlPart\(\) invoked with 1 parameter, 0 required\./', // dynamic checkbox is typehinted as BaseControl
+        '/Instantiated class MissingBlockParameter not found\./', # missing block parameter palceholder
     ];
 
     /** @var ErrorTransformerInterface[] */

--- a/src/Error/Transformer/BlockParameterErrorTransformer.php
+++ b/src/Error/Transformer/BlockParameterErrorTransformer.php
@@ -13,7 +13,7 @@ final class BlockParameterErrorTransformer implements ErrorTransformerInterface
     public function transform(Error $error): Error
     {
         preg_match(self::BLOCK_METHOD, $error->getMessage(), $match);
-        if (isset($match['block'])) {
+        if (isset($match['block']) && strpos($error->getMEssage(), 'MissingBlockParameter') === false) {
             $block = lcfirst(str_replace('_', '-', $match['block']));
             $message = ucfirst(str_replace($match[0], 'block ' . $block, $error->getMessage()));
             $error->setMessage($message);

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/SomeControl.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/SomeControl.php
@@ -15,6 +15,7 @@ final class SomeControl extends Control
         $this->template->knownString = 'a';
         $this->template->knownFloat = 1.23;
         $this->template->knownInteger = 123;
+        $this->template->knownArray = [new stdClass(), new stdClass()];
         $this->template->paramString = 'some string';
 
         $this->template->setFile(__DIR__ . '/define.latte');

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/define.latte
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/define.latte
@@ -1,4 +1,4 @@
-{define my-block, \stdClass $paramObject, string $paramString, ?string $paramNullable, $paramNoType, string $paramDefault = 'default', $paramNoTypeDefault = 'default', float $paramFloat = 1.23, int $paramInteger = 123}
+{define my-block, \stdClass $paramObject, string $paramString, ?string $paramNullable, $paramNoType, string $paramDefault = 'default', $paramNoTypeDefault = 'default', float $paramFloat = 1.23, int $paramInteger = 123, \stdClass[] $paramArray = []}
     {php \PhpStan\dumpType($paramObject)}
     {php \PhpStan\dumpType($paramString)}
     {php \PhpStan\dumpType($paramNullable)}
@@ -7,9 +7,10 @@
     {php \PhpStan\dumpType($paramNoTypeDefault)}
     {php \PhpStan\dumpType($paramFloat)}
     {php \PhpStan\dumpType($paramInteger)}
+    {php \PhpStan\dumpType($paramArray)}
 {/define}
 
-{include my-block 'paramObject' => $knownObject, 'paramString' => $knownString, 'paramNullable' => null, 'paramNoType' => $knownString, 'paramFloat' => $knownFloat, 'paramInteger' => $knownInteger}
+{include my-block 'paramObject' => $knownObject, 'paramString' => $knownString, 'paramNullable' => null, 'paramNoType' => $knownString, 'paramFloat' => $knownFloat, 'paramInteger' => $knownInteger, 'paramArray' => $knownArray}
 {include my-block 'paramObject' => $knownString, 'paramString' => $knownInteger}
 {include my-block $knownString, $knownInteger, 'paramInteger' => $knownInteger}
 

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -242,38 +242,43 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'define.latte',
             ],
             [
-                'Dumped type: float|null',
+                'Dumped type: float',
                 8,
                 'define.latte',
             ],
             [
-                'Dumped type: int|null',
+                'Dumped type: array<stdClass>',
+                10,
+                'define.latte',
+            ],
+            [
+                'Dumped type: int',
                 9,
                 'define.latte',
             ],
             [
                 'Parameter #1 $paramObject of block my-block expects stdClass|null, string given.',
-                13,
+                14,
                 'define.latte',
             ],
             [
                 'Parameter #2 $paramString of block my-block expects string|null, int given.',
-                13,
+                14,
                 'define.latte',
             ],
             [
                 'Parameter #1 $paramObject of block my-block expects stdClass|null, string given.',
-                14,
+                15,
                 'define.latte',
             ],
             [
                 'Parameter #2 $paramString of block my-block expects string|null, int given.',
-                14,
+                15,
                 'define.latte',
             ],
             [
                 'Dumped type: \'some string\'',
-                16,
+                17,
                 'define.latte',
             ],
         ]);


### PR DESCRIPTION
- support empty array as default value
- parameters with default value are not nullable
- differentiate between passing null and not passing parameter (it is ok to skip parameter, but it is not ok to pass null to not-nullable paameter)