### PR TITLE
Catching and transforming Invalid link error

### DIFF
--- a/src/Compiler/NodeVisitor/LinkNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/LinkNodeVisitor.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Echo_;
 use PhpParser\NodeVisitorAbstract;
+use Throwable;
 
 /**
  * changed output from:
@@ -123,6 +124,11 @@ final class LinkNodeVisitor extends NodeVisitorAbstract implements ActualClassNo
         } catch (InvalidPresenterException $e) {
             $errorNode = (new Error($e->getMessage()))
                 ->setTip('Check if your PHPStan configuration for latte > applicationMapping is correct. See https://github.com/efabrica-team/phpstan-latte/docs/configuration.md#applicationmapping')
+                ->toNode();
+            $errorNode->setAttributes($attributes);
+            return [$errorNode];
+        } catch (Throwable $e) {
+            $errorNode = (new Error($e->getMessage()))
                 ->toNode();
             $errorNode->setAttributes($attributes);
             return [$errorNode];

--- a/src/Error/Transformer/CallActionWithParametersMissingCorrespondingMethodErrorTransformer.php
+++ b/src/Error/Transformer/CallActionWithParametersMissingCorrespondingMethodErrorTransformer.php
@@ -8,7 +8,7 @@ use Efabrica\PHPStanLatte\Error\Error;
 
 final class CallActionWithParametersMissingCorrespondingMethodErrorTransformer implements ErrorTransformerInterface
 {
-    private const CALL_ACTION_WITH_PARAMETERS_REGEX = '/Call to an undefined method (?<presenter>.*)::(?<method>.*)WithParametersMissingCorrespondingMethod\(\)/';
+    private const CALL_ACTION_WITH_PARAMETERS_REGEX = '/Method (?<presenter>.*)::(?<method>.*)WithParametersMissingCorrespondingMethod not found/';
 
     public function transform(Error $error): Error
     {

--- a/src/LinkProcessor/PresenterActionLinkProcessor.php
+++ b/src/LinkProcessor/PresenterActionLinkProcessor.php
@@ -107,14 +107,14 @@ final class PresenterActionLinkProcessor implements LinkProcessorInterface
      */
     private function prepareMethodNames(string $presenterClassName, string $actionName, array $linkParams): array
     {
-        $presenterClassreflection = (new BetterReflection())->reflector()->reflectClass($presenterClassName);
+        $presenterClassReflection = (new BetterReflection())->reflector()->reflectClass($presenterClassName);
 
         $methodNames = [];
         $methodExists = false;
         // both methods have to have same parameters, so we check them both if exist
         foreach (['action', 'render'] as $type) {
             $methodName = $type . ucfirst($actionName);
-            if ($presenterClassreflection->hasMethod($methodName)) {
+            if ($presenterClassReflection->hasMethod($methodName)) {
                 $methodExists = true;
                 $methodNames[] = $methodName;
             }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Links/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Links/default.latte
@@ -90,3 +90,5 @@
 <a href="{link create persistent2: "persistent"}">With persistent attribute</a>
 <a href="{link create notPersistent: "not"}">With not persistent param</a>
 <a href="{link create persistentConflict: "persistent"}">Method param conflicts with persistent param</a>
+
+<a href="{link Links:nonExistingMethod param1 => test}">Call non-existing method with params</a>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -644,6 +644,12 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 91,
                 'default.latte',
             ],
+            [
+                'Invalid link: Unable to pass parameters to "' . LinksPresenter::class . '::nonExistingMethod()", missing corresponding method.',
+                94,
+                'default.latte',
+                'Add method actionNonExistingMethod or renderNonExistingMethod with corresponding parameters to presenter Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\LinksPresenter',
+            ],
         ];
         if (PHP_VERSION_ID < 80000) {
             $expectedErrors[] = [


### PR DESCRIPTION
Related to https://github.com/efabrica-team/phpstan-latte/issues/233

It is not fixing the issue, just transforming an error to more readable version.

```
Invalid link: Unable to pass parameters to "MichalSpacekCz\Admin\Presenters\InterviewsPresenter::slides()", missing corresponding method.                                                  
💡 Add method actionSlides or renderSlides with corresponding parameters to presenter MichalSpacekCz\Admin\Presenters\InterviewsPresenter
```

@spaze @MartinMystikJonas 

Do anybody know how it works when in
Interview/default.latte we include Talks/default.latte and in it there is 
```
<a n:href="slides $item->talkId">Slides</a>
```
?

We consider that "actual presenter" is InterviewPresenter, but it looks like after include "actual presenter" is changed to TalksPresenter. I've never use it this way so I'm not sure what is correct.

"Fix" is to use full path in href:
```
<a n:href="Talks:slides $item->talkId">Slides</a>
```