### PR TITLE
Caching compiled templates and line mapping refactoring

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -69,14 +69,17 @@ services:
 
     - Efabrica\PHPStanLatte\Analyser\FileAnalyserFactory
     - Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry(%analysedPaths%, %latte.reportUnanalysedTemplates%)
-    - Efabrica\PHPStanLatte\Compiler\LatteToPhpCompiler(%latte.tmpDir%, ::md5(::json_encode(%latte%)))
-
+    -
+        class: Efabrica\PHPStanLatte\Compiler\LatteToPhpCompiler
+        arguments:
+            tmpDir: %latte.tmpDir%
+            cacheKey: ::md5(::json_encode(%latte%))
+            debugMode: %debugMode%
     -
         factory: Efabrica\PHPStanLatte\Compiler\Postprocessor
         arguments:
             parser: @latteCurrentPhpVersionRichParser
 
-    - Efabrica\PHPStanLatte\Compiler\LineMapper
     - Efabrica\PHPStanLatte\Compiler\TypeToPhpDoc
     - Efabrica\PHPStanLatte\LinkProcessor\PresenterFactoryFaker(%latte.applicationMapping%)
     -
@@ -120,7 +123,6 @@ services:
             - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\ChangeNotNullToEqualsNullNodeVisitor())
             - addNodeVisitor(300, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddFormClassesNodeVisitor())
             - addNodeVisitor(9900, Efabrica\PHPStanLatte\Compiler\NodeVisitor\CleanupNodeVisitor())
-            - addNodeVisitor(10000, Efabrica\PHPStanLatte\Compiler\NodeVisitor\LineNumberNodeVisitor())
 
     # Link processors
     - Efabrica\PHPStanLatte\LinkProcessor\LinkProcessorFactory
@@ -174,6 +176,7 @@ services:
     - Efabrica\PHPStanLatte\VariableCollector\DynamicFilterVariables()
 
     # Error builder
+    - Efabrica\PHPStanLatte\Error\LineMapper\LineMapper(@latteCurrentPhpVersionRichParser, %debugMode%)
     - Efabrica\PHPStanLatte\Error\ErrorBuilder(%latte.errorPatternsToIgnore%, %latte.applicationMapping%)
 
     # Error transformers

--- a/src/Error/LineMapper/LineMap.php
+++ b/src/Error/LineMapper/LineMap.php
@@ -2,12 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Efabrica\PHPStanLatte\Compiler;
+namespace Efabrica\PHPStanLatte\Error\LineMapper;
 
-final class LineMapper
+final class LineMap
 {
     /** @var array<int, int> */
     private array $lines = [];
+
+    /**
+     * @param array<int, int> $lines
+     */
+    public function __construct(array $lines = [])
+    {
+        $this->lines = $lines;
+    }
 
     public function add(int $original, int $latte): void
     {
@@ -31,5 +39,13 @@ final class LineMapper
     public function reset(): void
     {
         $this->lines = [];
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function getLines(): array
+    {
+        return $this->lines;
     }
 }

--- a/src/Error/LineMapper/LineMapper.php
+++ b/src/Error/LineMapper/LineMapper.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Error\LineMapper;
+
+use InvalidArgumentException;
+use PhpParser\NodeTraverser;
+use PHPStan\Parser\Parser;
+
+final class LineMapper
+{
+    private Parser $parser;
+
+    private bool $debugMode;
+
+    /** @var array<string, LineMap> */
+    private array $lineMaps = [];
+
+    /**
+     * @param Parser $parser
+     */
+    public function __construct(Parser $parser, bool $debugMode = false)
+    {
+        $this->parser = $parser;
+        $this->debugMode = $debugMode;
+    }
+
+    public function getLineMap(string $compiledTemplatePath): LineMap
+    {
+        if (!file_exists($compiledTemplatePath)) {
+            throw new InvalidArgumentException('Compiled template file "' . $compiledTemplatePath . '" doesn\'t exist.');
+        }
+        if (isset($this->lineMaps[$compiledTemplatePath])) {
+            return $this->lineMaps[$compiledTemplatePath];
+        }
+        $lineMapFile = $compiledTemplatePath . '.map';
+        if ($this->debugMode || !file_exists($lineMapFile)) {
+            $lineMap = $this->parseLineMap($compiledTemplatePath);
+            file_put_contents($lineMapFile, json_encode($lineMap->getLines()));
+        } else {
+            /** @var array<int, int> $lines */
+            $lines = json_decode((string)file_get_contents($lineMapFile), true);
+            $lineMap = new LineMap($lines);
+        }
+        $this->lineMaps[$compiledTemplatePath] = $lineMap;
+        return $lineMap;
+    }
+
+    private function parseLineMap(string $compiledTemplatePath): LineMap
+    {
+        $phpStmts = (array)$this->parser->parseFile($compiledTemplatePath);
+        $lineMap = new LineMap();
+        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser->addVisitor(new LineNumberNodeVisitor($lineMap));
+        $nodeTraverser->traverse($phpStmts);
+        return $lineMap;
+    }
+}

--- a/src/Error/LineMapper/LineNumberNodeVisitor.php
+++ b/src/Error/LineMapper/LineNumberNodeVisitor.php
@@ -2,20 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor;
+namespace Efabrica\PHPStanLatte\Error\LineMapper;
 
-use Efabrica\PHPStanLatte\Compiler\LineMapper;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 final class LineNumberNodeVisitor extends NodeVisitorAbstract
 {
-    private LineMapper $lineMapper;
+    private LineMap $lineMap;
 
-    public function __construct(LineMapper $lineMapper)
+    public function __construct(LineMap $lineMap)
     {
-        $this->lineMapper = $lineMapper;
+        $this->lineMap = $lineMap;
     }
 
     public function enterNode(Node $node): ?Node
@@ -37,7 +36,7 @@ final class LineNumberNodeVisitor extends NodeVisitorAbstract
                 continue;
             }
 
-            $this->lineMapper->add($node->getStartLine(), $latteLine);
+            $this->lineMap->add($node->getStartLine(), $latteLine);
         }
 
         return null;

--- a/src/LatteTemplateResolver/LatteTemplateResolverResult.php
+++ b/src/LatteTemplateResolver/LatteTemplateResolverResult.php
@@ -77,6 +77,11 @@ final class LatteTemplateResolverResult
                 ->file($templateRender->getFile())
                 ->line($templateRender->getLine()));
             return;
+        } elseif (!is_file($templatePath)) {
+            $this->addErrorFromBuilder(RuleErrorBuilder::message('Rendered latte template ' . $templatePath . ' does not exist.')
+                ->file($templateRender->getFile())
+                ->line($templateRender->getLine()));
+            return;
         }
 
         $this->addTemplate(new Template(

--- a/src/Rule/LatteTemplatesRule.php
+++ b/src/Rule/LatteTemplatesRule.php
@@ -179,15 +179,23 @@ final class LatteTemplatesRule implements Rule
                     if ($includedTemplatePath[0] !== '/') {
                         $includedTemplatePath = $dir . '/' . $includedTemplatePath;
                     }
-                    $includedTemplatePath = realpath($includedTemplatePath) ?: $includedTemplatePath;
-                    $includeTemplate = new Template(
-                        $includedTemplatePath,
-                        $actualClass,
-                        $actualAction,
-                        $template->getTemplateContext()->mergeVariables($collectedTemplateRender->getVariables()),
-                        array_merge([$template->getPath()], $template->getParentTemplatePaths())
-                    );
-                    $includeTemplates[$includeTemplate->getSignatureHash()] = $includeTemplate;
+                    if (!is_file($includedTemplatePath)) {
+                        $errors[] = $this->errorBuilder->buildError(
+                            new Error('Included latte template ' . $includedTemplatePath . ' does not exist.', $collectedTemplateRender->getFile(), $collectedTemplateRender->getLine()),
+                            $templatePath,
+                            $compileFilePath
+                        );
+                    } else {
+                        $includedTemplatePath = realpath($includedTemplatePath) ?: $includedTemplatePath;
+                        $includeTemplate = new Template(
+                            $includedTemplatePath,
+                            $actualClass,
+                            $actualAction,
+                            $template->getTemplateContext()->mergeVariables($collectedTemplateRender->getVariables()),
+                            array_merge([$template->getPath()], $template->getParentTemplatePaths())
+                        );
+                        $includeTemplates[$includeTemplate->getSignatureHash()] = $includeTemplate;
+                    }
                 } elseif ($includedTemplatePath === '') {
                     $errors[] = $this->errorBuilder->buildError(
                         new Error('Empty path to included latte template.', $collectedTemplateRender->getFile(), $collectedTemplateRender->getLine()),

--- a/src/Rule/LatteTemplatesRule.php
+++ b/src/Rule/LatteTemplatesRule.php
@@ -149,7 +149,7 @@ final class LatteTemplatesRule implements Rule
                 $compileFilePath = $this->latteToPhpCompiler->compileFile($template, $context);
                 require($compileFilePath); // load type definitions from compiled template
             } catch (Throwable $e) {
-                $errors = array_merge($errors, $this->errorBuilder->buildErrors([new Error($e->getMessage() ?: get_class($e), $template->getPath())], $templatePath, $context));
+                $errors = array_merge($errors, $this->errorBuilder->buildErrors([new Error($e->getMessage() ?: get_class($e), $template->getPath())], $templatePath, null, $context));
                 continue;
             }
 
@@ -162,7 +162,7 @@ final class LatteTemplatesRule implements Rule
             );
             $this->analysedTemplatesRegistry->templateAnalysed($templatePath);
 
-            $errors = array_merge($errors, $this->errorBuilder->buildErrors($fileAnalyserResult->getErrors(), $templatePath, $context));
+            $errors = array_merge($errors, $this->errorBuilder->buildErrors($fileAnalyserResult->getErrors(), $templatePath, $compileFilePath, $context));
 
             if (count($errors) > 1000) {
                 return;
@@ -191,12 +191,14 @@ final class LatteTemplatesRule implements Rule
                 } elseif ($includedTemplatePath === '') {
                     $errors[] = $this->errorBuilder->buildError(
                         new Error('Empty path to included latte template.', $collectedTemplateRender->getFile(), $collectedTemplateRender->getLine()),
-                        $templatePath
+                        $templatePath,
+                        $compileFilePath
                     );
                 } elseif ($includedTemplatePath === false) {
                     $errors[] = $this->errorBuilder->buildError(
                         new Error('Cannot resolve included latte template.', $collectedTemplateRender->getFile(), $collectedTemplateRender->getLine()),
-                        $templatePath
+                        $templatePath,
+                        $compileFilePath
                     );
                 }
             }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
@@ -48,7 +48,6 @@ final class CollectorResultForSimpleControlTest extends CollectorResultTest
             'NODE NetteApplicationUIControl {"className":"SomeControl"}',
             'TEMPLATE default.latte SomeControl::render ["presenter","control","a","b"] []',
             'TEMPLATE test.latte SomeControl::renderTest ["presenter","control","c","d"] []',
-            'TEMPLATE invalid_file.latte SomeControl::renderTemplateFileNotFound ["presenter","control"] []',
             'TEMPLATE param_a.latte SomeControl::renderWildcard ["presenter","control","a","c"] []',
             'TEMPLATE param_b.latte SomeControl::renderWildcard ["presenter","control","a","c"] []',
         ]);

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/SomeControl.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/SomeControl.php
@@ -187,4 +187,9 @@ final class SomeControl extends Control
     {
         return $param ? 'a' : 'b';
     }
+
+    public function renderWrongFile(): void
+    {
+        $this->template->render(__DIR__ . '/error.latte');
+    }
 }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/default.latte
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/default.latte
@@ -1,1 +1,2 @@
 
+{include not-existing.latte}

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -124,9 +124,9 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'param_b.latte',
             ],
             [
-                'Template file "' . __DIR__ . '/Fixtures/MultipleRenderMethods/invalid_file.latte" doesn\'t exist.',
-                -1,
-                'invalid_file.latte',
+                'Rendered latte template ' . __DIR__ . '/Fixtures/MultipleRenderMethods/invalid_file.latte does not exist.',
+                41,
+                'SomeControl.php',
             ],
         ]);
     }
@@ -155,6 +155,12 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
     public function testResolve(): void
     {
         $this->analyse([__DIR__ . '/Fixtures/Resolve/SomeControl.php'], [
+            [
+                'Included latte template ' . __DIR__ . '/Fixtures/Resolve/not-existing.latte does not exist.',
+                2,
+                'default.latte',
+            ],
+
             [
                 'Variable $nonExistingVariable might not be defined.',
                 3,
@@ -194,6 +200,11 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'Variable $nonExistingVariable might not be defined.',
                 1,
                 'throwSometimes.latte',
+            ],
+            [
+                'Rendered latte template ' . __DIR__ . '/Fixtures/Resolve/error.latte does not exist.',
+                193,
+                'SomeControl.php',
             ],
         ]);
     }


### PR DESCRIPTION
Compiled teamplates ar cahce and not compiled every time when it is not needed (teste in my app and analysis time went from 1:45 to 1:20)

LineMap depended on compilation and was stored as global state. I reworked it as part of ErrorBuilder without global state and added caching too.