### PR TITLE
Use only required collectors on compiled templates to collect includes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,7 @@ parameters:
                 - '#^Creating new PHPStan\\Analyser\\Error is not covered by backward compatibility promise\. The class might change in a minor PHPStan version\.$#'
                 - '#^Property Efabrica\\PHPStanLatte\\Analyser\\LatteContextAnalyser::\$collectors with generic class Efabrica\\PHPStanLatte\\LatteContext\\Collector\\AbstractLatteContextCollector does not specify its types: N, T#'
                 - '#^Method Efabrica\\PHPStanLatte\\Analyser\\LatteContextAnalyser::__construct\(\) has parameter \$collectors with generic class Efabrica\\PHPStanLatte\\LatteContext\\Collector\\AbstractLatteContextCollector but does not specify its types: N, T#'
+                - '#^Method Efabrica\\PHPStanLatte\\Analyser\\LatteContextAnalyser::withCollectors\(\) has parameter \$collectors with generic class Efabrica\\PHPStanLatte\\LatteContext\\Collector\\AbstractLatteContextCollector but does not specify its types: N, T#'
             path: src/Analyser/LatteContextAnalyser.php
 
         # Latte version conditions

--- a/src/Analyser/LatteContextAnalyser.php
+++ b/src/Analyser/LatteContextAnalyser.php
@@ -147,4 +147,14 @@ class LatteContextAnalyser
         }
         return $files;
     }
+
+    /**
+     * @param AbstractLatteContextCollector[] $collectors
+     */
+    public function withCollectors(array $collectors): self
+    {
+        $clone = clone $this;
+        $clone->collectors = $collectors;
+        return $clone;
+    }
 }


### PR DESCRIPTION
I reuse LatteContextAnalyser with changed colelctors instead of creating new service. is it ok?

Do not seems like big change in tests. On ma computer difference is less than 1s on 40s run.
