### PR TITLE
Add keywords to prompt users if they would like to add the package to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
     "name": "efabrica/phpstan-latte",
     "license": ["MIT"],
-	"keywords": [
-		"static analysis"
-	],
+    "keywords": [
+        "static analysis"
+    ],
     "require": {
         "php": ">=7.4 <8.3",
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
     "name": "efabrica/phpstan-latte",
     "license": ["MIT"],
+	"keywords": [
+		"static analysis"
+	],
     "require": {
         "php": ">=7.4 <8.3",
         "ext-json": "*",


### PR DESCRIPTION
If they run `composer require` without the `--dev` option, see https://getcomposer.org/doc/04-schema.md#keywords