### PR TITLE
Ignore all named extra parameters in links check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Performance issues
 - Errors for skipped items in array deconstruct 
 - Removed no needed if statemen in compiled template for $formField->getLabel() when $formField is CheckboxList or RadioList 
+- Ignore all named extra parameters in links check (Nette appends them to query string)
 
 ## [0.4.0] - 2023-01-16
 ### Added

--- a/src/LinkProcessor/LinkParamsProcessor.php
+++ b/src/LinkProcessor/LinkParamsProcessor.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\BetterReflection\BetterReflection;
-use ReflectionProperty;
 
 final class LinkParamsProcessor
 {
@@ -34,8 +33,18 @@ final class LinkParamsProcessor
             throw new InvalidArgumentException('Too many parameters');
         }
 
-        $transferredParams = [];
+        $reflectionClass = (new BetterReflection())->reflector()->reflectClass($class);
+        $reflectionMethod = $reflectionClass->getMethod($method);
+        if ($reflectionMethod === null) {
+            throw new InvalidArgumentException("Method $class::$method not found");
+        }
 
+        $methodParameters = [];
+        foreach ($reflectionMethod->getParameters() as $param) {
+            $methodParameters[] = $param->getName();
+        }
+
+        $transferredParams = [];
         if ($params !== []) {
             $paramValue = $params[0]->value;
             if (!$paramValue instanceof Array_) {
@@ -47,7 +56,12 @@ final class LinkParamsProcessor
                     continue;
                 }
                 $key = $arrayItem->key;
-                if ($key instanceof String_) {  // ignore key for now
+                if ($key instanceof String_) {
+                    $transferredParamName = $key->value;
+                    // Skip named params which are not method params - Nette adds them to query params (e.g. ?param1=foo&param2=bar) and not check if they are in method
+                    if (!in_array($transferredParamName, $methodParameters, true)) {
+                        continue;
+                    }
                     $arrayItem = new ArrayItem($arrayItem->value, null, $arrayItem->byRef, $arrayItem->getAttributes());
                     $transferredParams[$key->value] = new Arg($arrayItem);
                     continue;
@@ -56,18 +70,10 @@ final class LinkParamsProcessor
             }
         }
 
-        $reflectionClass = (new BetterReflection())->reflector()->reflectClass($class);
-        $reflectionMethod = $reflectionClass->getMethod($method);
-        if ($reflectionMethod === null) {
-            throw new InvalidArgumentException("Method $class::$method not found");
-        }
-
         $i = 0;
-        $methodParameters = [];
         foreach ($reflectionMethod->getParameters() as $param) {
             $name = $param->getName();
             $type = (string) $param->getType();
-            $methodParameters[] = $name;
             if (array_key_exists($i, $transferredParams)) {
                 $transferredParams[$name] = $transferredParams[$i];
                 unset($transferredParams[$i]);
@@ -83,19 +89,6 @@ final class LinkParamsProcessor
                 $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue([]));
             } else {
                 $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue(null));
-            }
-        }
-
-        // remove persistent parameters
-        foreach ($reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-            if (in_array($property->getName(), $methodParameters, true)) {
-                continue;
-            }
-            if (preg_match_all('#[\s*]@persistent(?:\(\s*([^)]*)\s*\)|\s|$)#', (string) $property->getDocComment(), $m)) {
-                unset($transferredParams[$property->getName()]);
-            }
-            if (PHP_VERSION_ID >= 80000 && $property->getAttributesByInstance('Nette\Application\Attributes\Persistent')) {
-                unset($transferredParams[$property->getName()]);
             }
         }
 

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -518,26 +518,6 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
-                'Method ' . LinksPresenter::class . '::actionCreate() invoked with 1 parameter, 0 required.',
-                13,
-                'default.latte',
-            ],
-            [
-                'Method ' . LinksPresenter::class . '::actionCreate() invoked with 1 parameter, 0 required.',
-                14,
-                'default.latte',
-            ],
-            [
-                'Method ' . LinksPresenter::class . '::actionCreate() invoked with 1 parameter, 0 required.',
-                16,
-                'default.latte',
-            ],
-            [
-                'Method ' . LinksPresenter::class . '::actionCreate() invoked with 1 parameter, 0 required.',
-                17,
-                'default.latte',
-            ],
-            [
                 'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, null given.',
                 20,
                 'default.latte',
@@ -565,26 +545,6 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
             [
                 'Parameter #1 $id of method ' . LinksPresenter::class . '::actionEdit() expects string, array<string, int|string> given.',
                 39,
-                'default.latte',
-            ],
-            [
-                'Method ' . LinksPresenter::class . '::actionEdit() invoked with 3 parameters, 1-2 required.',
-                56,
-                'default.latte',
-            ],
-            [
-                'Method ' . LinksPresenter::class . '::actionEdit() invoked with 3 parameters, 1-2 required.',
-                57,
-                'default.latte',
-            ],
-            [
-                'Method ' . LinksPresenter::class . '::actionEdit() invoked with 3 parameters, 1-2 required.',
-                59,
-                'default.latte',
-            ],
-            [
-                'Method ' . LinksPresenter::class . '::actionEdit() invoked with 3 parameters, 1-2 required.',
-                60,
                 'default.latte',
             ],
             [
@@ -639,24 +599,12 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
-                'Method ' . LinksPresenter::class . '::actionCreate() invoked with 1 parameter, 0 required.',
-                91,
-                'default.latte',
-            ],
-            [
                 'Invalid link: Unable to pass parameters to "' . LinksPresenter::class . '::nonExistingMethod()", missing corresponding method.',
                 94,
                 'default.latte',
                 'Add method actionNonExistingMethod or renderNonExistingMethod with corresponding parameters to presenter Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\LinksPresenter',
             ],
         ];
-        if (PHP_VERSION_ID < 80000) {
-            $expectedErrors[] = [
-                'Method ' . LinksPresenter::class . '::actionCreate() invoked with 1 parameter, 0 required.',
-                90,
-                'default.latte',
-            ];
-        }
         $this->analyse([__DIR__ . '/Fixtures/LinksPresenter.php'], $expectedErrors);
     }
 


### PR DESCRIPTION
Resolves https://github.com/efabrica-team/phpstan-latte/issues/198

Named parameters are added to url if they match some method parameter name or if they are named. Other parameters raise exception `Invalid link: Unable to pass parameters to action 'Presenter:action', missing corresponding method.`

So we can ignore named extra parameters because Nette appends them to url query string.