### PR TITLE
Fixed analysed template registry - cast SplFileInfo object to string

### DIFF
--- a/src/Analyser/AnalysedTemplatesRegistry.php
+++ b/src/Analyser/AnalysedTemplatesRegistry.php
@@ -54,10 +54,11 @@ final class AnalysedTemplatesRegistry
             }
             /** @var string $file */
             foreach (Finder::findFiles('*.latte')->from($analysedPath) as $file) {
-                if ($this->isExcludedFromAnalysing($file)) {
+                $filePath = (string)$file;
+                if ($this->isExcludedFromAnalysing($filePath)) {
                     continue;
                 }
-                $files[] = (string)$file;
+                $files[] = $filePath;
             }
         }
         $files = array_unique($files);


### PR DESCRIPTION
```
TypeError: Argument 1 passed to Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry::isExcludedFromAnalysing() must be of the type string, object given, called in /var/www/libs/efabrica/phpstan-latte/src/Analyser/AnalysedTemplatesRegistry.php on line 57 in /var/www/libs/efabrica/phpstan-latte/src/Analyser/AnalysedTemplatesRegistry.php:35
#0 /var/www/libs/efabrica/phpstan-latte/src/Analyser/AnalysedTemplatesRegistry.php(57): Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry->isExcludedFromAnalysing(Object(SplFileInfo))
#1 /var/www/libs/efabrica/phpstan-latte/src/Analyser/AnalysedTemplatesRegistry.php(30): Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry->getExistingTemplates()
#2 /tmp/phpstan/cache/nette.configurator/Container_b1fae6f880.php(5251): Efabrica\PHPStanLatte\Analyser\AnalysedTemplatesRegistry->__construct(Object(PHPStan\File\FileExcluder), Array, false)
```