### PR TITLE
Prevent errors when dynamic names for components are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased][unreleased]
 
 ### Fixed
-- exit() and die() evaluated as early terminating call 
+- exit() and die() evaluated as early terminating call
+- Resolve only public methods with name render* or action*
+- Prevent errors when dynamic components are used
 
 ## [0.5.0] - 2023-01-24
 ### Added

--- a/src/Compiler/NodeVisitor/CleanupNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/CleanupNodeVisitor.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor;
 
 use Efabrica\PHPStanLatte\Resolver\NameResolver\NameResolver;
+use InvalidArgumentException;
+use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
@@ -65,28 +74,58 @@ final class CleanupNodeVisitor extends NodeVisitorAbstract
 
         if ($node instanceof If_) {
             // replace if (false) to next condition
-            if (!($node->cond instanceof ConstFetch && $this->nameResolver->resolve($node->cond->name) === 'false')) {
-                return null;
-            }
-
-            $elseIfs = $node->elseifs;
-            $else = $node->else;
-            $firstElseIf = array_shift($elseIfs);
-            if ($firstElseIf === null) {
-                if (!$else instanceof Else_) {
-                    // no elseif nor else
-                    return NodeTraverser::REMOVE_NODE;
+            if ($node->cond instanceof ConstFetch && $this->nameResolver->resolve($node->cond->name) === 'false') {
+                $elseIfs = $node->elseifs;
+                $else = $node->else;
+                $firstElseIf = array_shift($elseIfs);
+                if ($firstElseIf === null) {
+                    if (!$else instanceof Else_) {
+                        // no elseif nor else
+                        return NodeTraverser::REMOVE_NODE;
+                    }
+                    // only else
+                    return $else->stmts;
                 }
-                // only else
-                return $else->stmts;
+
+                $subnodes = [
+                    'stmts' => $firstElseIf->stmts,
+                    'elseifs' => $elseIfs,
+                    'else' => $else,
+                ];
+                return new If_($firstElseIf->cond, $subnodes, $node->getAttributes());
             }
 
-            $subnodes = [
-                'stmts' => $firstElseIf->stmts,
-                'elseifs' => $elseIfs,
-                'else' => $else,
-            ];
-            return new If_($firstElseIf->cond, $subnodes, $node->getAttributes());
+            // Prevent error: "Call to function is_object() with * will always evaluate to true / false." on dynamic components
+            if (($node->cond instanceof FuncCall && $this->nameResolver->resolve($node->cond->name) === 'is_object') ||
+                $node->cond instanceof BooleanNot && $node->cond->expr instanceof FuncCall && $this->nameResolver->resolve($node->cond->expr->name) === 'is_object'
+            ) {
+                $firstStmt = $node->stmts[0] ?? null;
+
+                if ($firstStmt instanceof Expression &&
+                    $firstStmt->expr instanceof Assign &&
+                    $firstStmt->expr->var instanceof Variable &&
+                    in_array($varName = $this->nameResolver->resolve($firstStmt->expr->var), ['_tmp', 'ʟ_tmp'], true)
+                ) {
+                    $docComment = $node->getDocComment();
+                    $docComments = $docComment ? [$docComment->getText()] : [];
+                    $docComments[] = '/** @phpstan-ignore-next-line */';
+                    $node->setDocComment(new Doc(implode("\n", $docComments)));
+
+                    $nodes = [];
+                    if ($node->cond instanceof BooleanNot && $node->cond->expr instanceof FuncCall && isset($node->cond->expr->getArgs()[0])) { // latte 3
+                        $nodes[] = new Expression($node->cond->expr->getArgs()[0]->value);
+                        $node->cond->expr->args[0] = new Arg(new Variable($varName));
+                    }
+                    $nodes[] = $node;
+                    $nodes[] = new If_(new Identical(new Variable($varName), new ConstFetch(new Name('null'))), [
+                        'stmts' => [
+                            new Expression(new Throw_(new New_(new Name(InvalidArgumentException::class)))),
+                        ],
+                    ]);
+
+                    return $nodes;
+                }
+            }
         }
 
         return null;

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Components/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Components/default.latte
@@ -25,3 +25,8 @@
 {control noType}
 
 {control implicitType}
+
+{var $components = ['form', 'parentForm']}
+{foreach $components as $component}
+    {control $component}
+{/foreach}


### PR DESCRIPTION
Resolves https://github.com/efabrica-team/phpstan-latte/issues/293

At the end it was little bit more complicated, and of course different in latte 2 and latte 3