### PR TITLE
Rewritten TerminatingCallResolver to use phpstan’s built-in method

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -107,7 +107,7 @@ services:
 
     # Method resolvers
     - Efabrica\PHPStanLatte\Resolver\CallResolver\CalledClassResolver
-    - Efabrica\PHPStanLatte\Resolver\CallResolver\TerminatingCallResolver(%earlyTerminatingMethodCalls%)
+    - Efabrica\PHPStanLatte\Resolver\CallResolver\TerminatingCallResolver(%earlyTerminatingMethodCalls%, %earlyTerminatingFunctionCalls%)
     - Efabrica\PHPStanLatte\Resolver\CallResolver\OutputCallResolver()
 
     phpstanLatteNodeVisitorStorage:


### PR DESCRIPTION
I found this method in NodeScopeResolver and I used it. Tests are green, so I think we should keep it. Can you please check other places where early terminating is collected and use this method instead of some custom written?