### PR TITLE
Added stubs for filters accepting any value which could be converted to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- stubs for filters accepting any value which could be converted to string
+
 ### Fixed
-- exit() and die() evaluated as early terminating call 
+- exit() and die() evaluated as early terminating call
 
 ## [0.5.0] - 2023-01-24
 ### Added

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,10 @@
 parameters:
+    stubFiles:
+        - stubs/Latte/Runtime/FilterInfo.stub
+        - stubs/Latte/Runtime/Filters.stub
+        - stubs/Latte/Runtime/HtmlStringable.stub
+        - stubs/Nette/HtmlStringable.stub
+        - stubs/Stringable.stub
     usePathConstantsAsConstantString: true
     latte:
         strictMode: false

--- a/stubs/Latte/Runtime/FilterInfo.stub
+++ b/stubs/Latte/Runtime/FilterInfo.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Latte\Runtime;
+
+class FilterInfo
+{
+}

--- a/stubs/Latte/Runtime/Filters.stub
+++ b/stubs/Latte/Runtime/Filters.stub
@@ -1,0 +1,160 @@
+<?php
+
+namespace Latte\Runtime;
+
+use Latte\Runtime\HtmlStringable as LatteRuntimeHtmlStringable;
+use Nette\HtmlStringable as NetteHtmlStringable;
+use Stringable;
+
+/**
+ * @phpstan-type FilterString string|int|float|bool|Stringable|NetteHtmlStringable|LatteRuntimeHtmlStringable
+ */
+class Filters
+{
+    /**
+     * @param FilterString $s
+     */
+    public static function escapeHtml($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function escapeHtmlComment($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function escapeXml($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function escapeCss($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function escapeJs($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function escapeICal($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function stripHtml(FilterInfo $info, $s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function stripTags(FilterInfo $info, $s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function safeUrl($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function repeat(FilterInfo $info, $s, int $count): string
+    {
+    }
+
+    /**
+     * @param FilterString $subject
+     */
+    public static function replace(FilterInfo $info, $subject, $search, $replace = null): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function breaklines($s): Html
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function substring($s, int $start, ?int $length = null): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function truncate($s, int $length, string $append = "\u{2026}"): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function lower($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function upper($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function firstUpper($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function capitalize($s): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function trim(FilterInfo $info, $s, string $charlist = " \t\n\r\0\x0B\u{A0}"): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function padLeft($s, int $length, string $append = ' '): string
+    {
+    }
+
+    /**
+     * @param FilterString $s
+     */
+    public static function padRight($s, int $length, string $append = ' '): string
+    {
+    }
+}

--- a/stubs/Latte/Runtime/HtmlStringable.stub
+++ b/stubs/Latte/Runtime/HtmlStringable.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Latte\Runtime;
+
+interface HtmlStringable
+{
+}

--- a/stubs/Nette/HtmlStringable.stub
+++ b/stubs/Nette/HtmlStringable.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nette;
+
+interface HtmlStringable
+{
+}

--- a/stubs/Stringable.stub
+++ b/stubs/Stringable.stub
@@ -1,0 +1,5 @@
+<?php
+
+interface Stringable
+{
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Variables/default.latte
@@ -80,3 +80,10 @@
 {php \PhpStan\dumpType($list2WithType)}
 
 {$dynamic}
+
+{var $top = round(456 / 10)};
+<style>
+    .foo-bar {
+        top: {$top}%;
+    }
+</style>


### PR DESCRIPTION
Resolves https://github.com/efabrica-team/phpstan-latte/issues/298

I think this is very elegant solution for wrong typehints in nette / latte itself. Each of these methods has phpdoc typehint for parameter ($s) - string or mixed, but first thing what they do at their body is casting input to string - so they accepts all "stringable" inputs.

I've created FilterString as an alias for string|int|float|bool|Stringable|NetteHtmlStringable|LatteRuntimeHtmlStringable. If there are any other types which could be included, please report or add them yourself.