### PR TITLE
Fixed slice stubs

### DIFF
--- a/stubs/Latte/Essential/Filters.stub
+++ b/stubs/Latte/Essential/Filters.stub
@@ -5,8 +5,9 @@ namespace Latte\Essential;
 final class Filters
 {
     /**
-     * @param string|array $value
-     * @return ($value is string ? string : array)
+     * @template T
+     * @param string|array<T> $value
+     * @return ($value is string ? string : array<T>)
      */
     public static function slice($value, int $start, ?int $length = null, bool $preserveKeys = false)
     {

--- a/stubs/Latte/Runtime/Filters.stub
+++ b/stubs/Latte/Runtime/Filters.stub
@@ -161,8 +161,9 @@ class Filters
     }
 
     /**
-     * @param string|array $value
-     * @return ($value is string ? string : array)
+     * @template T
+     * @param string|array<T> $value
+     * @return ($value is string ? string : array<T>)
      */
     public static function slice($value, int $start, ?int $length = null, bool $preserveKeys = false)
     {

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -161,7 +161,7 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
-                'Dumped type: array',
+                'Dumped type: array<string>',
                 92,
                 'default.latte',
             ],


### PR DESCRIPTION
Prevents "...no value type specified in iterable type array" on higher levels