### PR TITLE
Fixed evaluation of encapsed strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=7.4 <8.3",
         "ext-json": "*",
-        "phpstan/phpstan": "^1.9.4",
+        "phpstan/phpstan": "^1.10.1",
         "phpstan/phpstan-nette": "^1.2",
         "latte/latte": "^2.11.6 | ^3.0.4",
         "nette/utils": "^3.2",

--- a/src/Analyser/LatteContextCollectorRegistry.php
+++ b/src/Analyser/LatteContextCollectorRegistry.php
@@ -32,7 +32,7 @@ final class LatteContextCollectorRegistry
     {
         $nodeType = get_class($node);
         if (!isset($this->cache[$nodeType])) {
-            $parentNodeTypes = [$nodeType] + class_parents($nodeType) + class_implements($nodeType);
+            $parentNodeTypes = [$nodeType] + (array)class_parents($nodeType) + (array)class_implements($nodeType);
             $collectors = [];
             foreach ($parentNodeTypes as $parentNodeType) {
                 foreach ($this->collectors[$parentNodeType] ?? [] as $collector) {

--- a/src/Resolver/ValueResolver/ValueResolver.php
+++ b/src/Resolver/ValueResolver/ValueResolver.php
@@ -59,7 +59,11 @@ final class ValueResolver
             if ($expr instanceof Encapsed) {
                 $result = [];
                 foreach ($expr->parts as $part) {
-                    $options = $this->resolve($part, $scope, $fallbackEvaluator);
+                    if ($part instanceof EncapsedStringPart) {
+                        $options = [$part->value];
+                    } else {
+                        $options = $this->resolve($part, $scope, $fallbackEvaluator);
+                    }
                     if ($options === null || count($options) !== 1) {
                         throw new ConstExprEvaluationException();
                     }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -670,21 +670,25 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'Comparison operation ">" between 10 and 0 is always true.',
                 2,
                 'recursion.latte',
+                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Comparison operation ">" between 9 and 0 is always true.',
                 2,
                 'recursion.latte',
+                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Comparison operation ">" between 8 and 0 is always true.',
                 2,
                 'recursion.latte',
+                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Comparison operation ">" between 7 and 0 is always true.',
                 2,
                 'recursion.latte',
+                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Dumped type: 9',


### PR DESCRIPTION
No idea why this do not happen in tests but in real project I encountered this:

```
Cannot directly print EncapsedStringPart in phar:///app/tools/devstack/phpstan/phpstan/phpstan.phar/vendor/nikic/php-parser/lib
/PhpParser/PrettyPrinter/Standard.php on line #0 phar:///app/tools/devstack/phpstan/phpstan/phpstan.phar/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(499): PhpParser\PrettyPrinter\Standard->pScalar_EncapsedStringPart(Object(PhpParser\Node\Scalar\EncapsedStringPart))
#1 phar:///app/tools/devstack/phpstan/phpstan/phpstan.phar/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(215): PhpParser\PrettyPrinterAbstract->p(Object(PhpParser\Node\Scalar\EncapsedStringPart))
#2 phar:///app/tools/devstack/phpstan/phpstan/phpstan.phar/src/Node/Printer/ExprPrinter.php(23): PhpParser\PrettyPrinterAbstract->prettyPrintExpr(Object(PhpParser\Node\Scalar\EncapsedStringPart))
#3 phar:///app/tools/devstack/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php(562): PHPStan\Node\Printer\ExprPrinter->printExpr(Object(PhpParser\Node\Scalar\EncapsedStringPart))
#4 phar:///app/tools/devstack/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php(554): PHPStan\Analyser\MutatingScope->getNodeKey(Object(PhpParser\Node\Scalar\EncapsedStringPart))
#5 /app/tools/devstack/efabrica/phpstan-latte/src/Resolver/ValueResolver/ValueResolver.php(105): PHPStan\Analyser\MutatingScope->getType(Object(PhpParser\Node\Scalar\EncapsedStringPart))
#6 /app/tools/devstack/efabrica/phpstan-latte/src/Resolver/ValueResolver/ValueResolver.php(62): Efabrica\PHPStanLatte\Resolver\ValueResolver\ValueResolver->resolve(Object(PhpParser\Node\Scalar\EncapsedStringPart), Object(PHPStan\Analyser\MutatingScope), NULL) 
#7 phar:///app/tools/devstack/phpstan/phpstan/phpstan.phar/vendor/nikic/php-parser/lib/PhpParser/ConstExprEvaluator.php(131): Efabrica\PHPStanLatte\Resolver\ValueResolver\ValueResolver->Efabrica\PHPStanLatte\Resolver\ValueResolver\{closure}(Object(PhpParser\Node\Scalar\Encapsed))
...
```