### PR TITLE
Replace better reflection with PHPStan ReflectionProvider - part 1

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -129,22 +129,23 @@ services:
     phpstanLatteNodeVisitorStorage:
         factory: Efabrica\PHPStanLatte\Compiler\NodeVisitor\NodeVisitorStorage
         setup:
+            # no scope node visitors
             - addNodeVisitor(50, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddParametersForBlockNodeVisitor())
             - addNodeVisitor(50, Efabrica\PHPStanLatte\Compiler\NodeVisitor\CopyDefinedVarsToOtherMethodsNodeVisitor())
             - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddTypeToComponentNodeVisitor())
             - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddVarTypesNodeVisitor(%latte.globalVariables%))
             - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\RemoveExtractParamsNodeVisitor())
             - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\RenderBlockNodeVisitor())
-            - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\ChangeFiltersNodeVisitor())
-            - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\ChangeFunctionsNodeVisitor())
-            - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddExtractParamsToTopNodeVisitor())
             - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\TransformNClassNodeVisitor())
             - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\TransformForeachWithIteratorNodeVisitor())
             - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\LinkNodeVisitor())
             - addNodeVisitor(200, Efabrica\PHPStanLatte\Compiler\NodeVisitor\ChangeNotNullToEqualsNullNodeVisitor())
             - addNodeVisitor(300, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddFormClassesNodeVisitor())
             - addNodeVisitor(9900, Efabrica\PHPStanLatte\Compiler\NodeVisitor\CleanupNodeVisitor())
-
+            # scope node visitors
+            - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\ChangeFiltersNodeVisitor())
+            - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\ChangeFunctionsNodeVisitor())
+            - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddExtractParamsToTopNodeVisitor())
     # Link processors
     - Efabrica\PHPStanLatte\LinkProcessor\LinkProcessorFactory
     - Efabrica\PHPStanLatte\LinkProcessor\LinkParamsProcessor

--- a/src/Compiler/NodeVisitor/AddExtractParamsToTopNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddExtractParamsToTopNodeVisitor.php
@@ -4,20 +4,40 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor;
 
+use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ExprTypeNodeVisitorBehavior;
+use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ExprTypeNodeVisitorInterface;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeVisitorAbstract;
+use PHPStan\Type\ObjectType;
 
-final class AddExtractParamsToTopNodeVisitor extends NodeVisitorAbstract
+final class AddExtractParamsToTopNodeVisitor extends NodeVisitorAbstract implements ExprTypeNodeVisitorInterface
 {
+    use ExprTypeNodeVisitorBehavior;
+
     public function enterNode(Node $node): ?Node
     {
         if (!$node instanceof ClassMethod) {
+            return null;
+        }
+
+        $class = $node->getAttribute('parent');
+        if (!$class instanceof Class_) {
+            return null;
+        }
+
+        $type = $this->getType($class);
+        if (!$type instanceof ObjectType) {
+            return null;
+        }
+
+        if (!$type->isInstanceOf('\Latte\Runtime\Template')->yes()) {
             return null;
         }
 

--- a/src/Compiler/NodeVisitor/Behavior/ScopeNodeVisitorBehavior.php
+++ b/src/Compiler/NodeVisitor/Behavior/ScopeNodeVisitorBehavior.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior;
+
+use Exception;
+use PHPStan\Analyser\Scope;
+
+trait ScopeNodeVisitorBehavior
+{
+    private ?Scope $scope = null;
+
+    public function setScope(Scope $scope): void
+    {
+        $this->scope = $scope;
+    }
+
+    public function getScope(): Scope
+    {
+        if ($this->scope === null) {
+            throw new Exception('Scope has not been set');
+        }
+        return $this->scope;
+    }
+}

--- a/src/Compiler/NodeVisitor/Behavior/ScopeNodeVisitorInterface.php
+++ b/src/Compiler/NodeVisitor/Behavior/ScopeNodeVisitorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior;
+
+use PHPStan\Analyser\Scope;
+
+interface ScopeNodeVisitorInterface
+{
+    public function setScope(Scope $scope): void;
+}

--- a/src/Compiler/NodeVisitor/NodeVisitorStorage.php
+++ b/src/Compiler/NodeVisitor/NodeVisitorStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor;
 
 use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ExprTypeNodeVisitorInterface;
+use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ScopeNodeVisitorInterface;
 use InvalidArgumentException;
 use PhpParser\NodeVisitor;
 
@@ -25,7 +26,7 @@ final class NodeVisitorStorage
         if ($priority < 0 || $priority > 10000) {
             throw new InvalidArgumentException('Priority must be set between 0 and 10000');
         }
-        $scope = $nodeVisitor instanceof ExprTypeNodeVisitorInterface ? self::WITH_SCOPE : self::WITHOUT_SCOPE;
+        $scope = $nodeVisitor instanceof ExprTypeNodeVisitorInterface || $nodeVisitor instanceof ScopeNodeVisitorInterface ? self::WITH_SCOPE : self::WITHOUT_SCOPE;
         if (!isset($this->nodeVisitors[$scope][$priority])) {
             $this->nodeVisitors[$scope][$priority] = [];
         }


### PR DESCRIPTION
Ref: https://github.com/efabrica-team/phpstan-latte/issues/266

@MartinMystikJonas 

Replaced BetterReflection with ReflectionProvider in NodeVisitors. I can't find some methods from BetterReflection in ReflectionProvider (e.g. reflectFunction, ReflectionFunction::createFromClosure()),  so they are still used there. Also I'm not sure if this is such valueable, because I had to rewrite few other NodeVisitors, and also ReflectionProvider->getClass()->getMethod() requires Scope as second parameter. I don't see such benefit in this approach. But it is working now so we can merge it if you want.

There are still some classes using BetterReflection, but they were added by you and I am not sure how to replace them.