### PR TITLE
Can also use nette/utils v4 and nette/finder v3

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -12,7 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '8.0', '8.1', '8.2' ]
+        php: [ '8.0', '8.1', '8.2' ]
+        outdated-args: [ '--ignore=phpunit/phpunit' ]
+        include:
+          - php: '7.4'
+            outdated-args: '--ignore=nette/finder --ignore=phpunit/phpunit'
 
     name: Composer outdated - PHP ${{ matrix.php }}
 
@@ -29,4 +33,4 @@ jobs:
         run: composer update --no-progress --no-interaction
 
       - name: Composer outdated
-        run: composer outdated -D --strict --ignore=nette/finder --ignore=nette/utils --ignore=phpunit/phpunit
+        run: composer outdated -D --strict ${{ matrix.outdated-args }}

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "phpstan/phpstan": "^1.10.6",
         "phpstan/phpstan-nette": "^1.2",
         "latte/latte": "^2.11.6 | ^3.0.4",
-        "nette/utils": "^3.2",
-        "nette/finder": "^2.5"
+        "nette/utils": "^3.2|^4.0",
+        "nette/finder": "^2.5|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/tests/Rule/LatteTemplatesRule/Annotations/CollectorResultForAnnotationsTest.php
+++ b/tests/Rule/LatteTemplatesRule/Annotations/CollectorResultForAnnotationsTest.php
@@ -30,7 +30,7 @@ final class CollectorResultForAnnotationsTest extends ScanCollectorResultTest
     public function fixtures(): array
     {
         $fixtures = [];
-        foreach (Finder::findDirectories()->in(__DIR__ . '/Fixtures') as $path) {
+        foreach (Finder::findDirectories('*')->in(__DIR__ . '/Fixtures') as $path) {
             $fixtures[] = [$path->getFilename()];
         }
         return $fixtures;

--- a/tests/Rule/LatteTemplatesRule/Annotations/LatteTemplateRuleForAnnotationsTest.php
+++ b/tests/Rule/LatteTemplatesRule/Annotations/LatteTemplateRuleForAnnotationsTest.php
@@ -31,7 +31,7 @@ final class LatteTemplateRuleForAnnotationsTest extends ScanLatteTemplatesRuleTe
     public function fixtures(): array
     {
         $fixtures = [];
-        foreach (Finder::findDirectories()->in(__DIR__ . '/Fixtures') as $path) {
+        foreach (Finder::findDirectories('*')->in(__DIR__ . '/Fixtures') as $path) {
             $fixtures[] = [$path->getFilename()];
         }
         return $fixtures;


### PR DESCRIPTION
In v3, finder has been moved to utils v4.

Release notes:
- https://github.com/nette/utils/releases/tag/v4.0.0
- https://github.com/nette/finder/releases/tag/v3.0.0

---
Note: the tests are failing because of a newer coding standard is available, if I update it, they stop failing, see the [results here](https://github.com/efabrica-team/phpstan-latte/actions/runs/4521944894) when updated.

#331 updates the coding standard so maybe it should be merged first.