### PR TITLE
Params in block / define are analysed in the same way as they are defined by developer - they are no longer optional with default value `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Changed
+- Params in block / define are analysed in the same way as they are defined by developer - they are no longer optional with default value `null` 
+
 ### Added
 - Support for try / catch in foreach
 

--- a/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
@@ -11,9 +11,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\LNumber;
@@ -86,12 +84,11 @@ final class AddParametersForBlockNodeVisitor extends NodeVisitorAbstract
                 } elseif ($defaultValue === '[]') {
                     $default = new Array_();
                 } else {
-                    $default = new ConstFetch(new Name('null'));
+                    $default = null;
                 }
 
-                // Type is always nullable - all params are optional in latte unless they have default value
-                $type = ltrim(trim($parameters['type'][$i]), '?');
-                $nodeComment .= ' * @param ' . ($type && !$defaultValue ? '?' : '') . ($type ? $type . ' ' : '') . '$' . $parameters['variable'][$i] . "\n";
+                $type = trim($parameters['type'][$i]);
+                $nodeComment .= ' * @param ' . ($type ? $type . ' ' : '') . '$' . $parameters['variable'][$i] . "\n";
 
                 $node->params[] = new Param(new Variable($parameters['variable'][$i]), $default);
             }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -233,12 +233,12 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'define.latte',
             ],
             [
-                'Dumped type: stdClass|null',
+                'Dumped type: stdClass',
                 2,
                 'define.latte',
             ],
             [
-                'Dumped type: string|null',
+                'Dumped type: string',
                 3,
                 'define.latte',
             ],
@@ -253,7 +253,7 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'define.latte',
             ],
             [
-                'Dumped type: string|null',
+                'Dumped type: string',
                 6,
                 'define.latte',
             ],
@@ -268,32 +268,32 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'define.latte',
             ],
             [
-                'Dumped type: array<stdClass>',
-                10,
-                'define.latte',
-            ],
-            [
                 'Dumped type: int',
                 9,
                 'define.latte',
             ],
             [
-                'Parameter #1 $paramObject of block my-block expects stdClass|null, string given.',
+                'Dumped type: array<stdClass>',
+                10,
+                'define.latte',
+            ],
+            [
+                'Parameter #1 $paramObject of block my-block expects stdClass, string given.',
                 14,
                 'define.latte',
             ],
             [
-                'Parameter #2 $paramString of block my-block expects string|null, int given.',
+                'Parameter #2 $paramString of block my-block expects string, int given.',
                 14,
                 'define.latte',
             ],
             [
-                'Parameter #1 $paramObject of block my-block expects stdClass|null, string given.',
+                'Parameter #1 $paramObject of block my-block expects stdClass, string given.',
                 15,
                 'define.latte',
             ],
             [
-                'Parameter #2 $paramString of block my-block expects string|null, int given.',
+                'Parameter #2 $paramString of block my-block expects string, int given.',
                 15,
                 'define.latte',
             ],


### PR DESCRIPTION
Resolves https://github.com/efabrica-team/phpstan-latte/issues/335