### PR TITLE
Improved processing of block's missing parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased][unreleased]
 
+### Changed
+- Improved processing of block's missing parameters - default value is used if it is available
+
+### Fixed
+- String default values for blocks
+- Blocks called with no parameters are also transfered to method call
+
 ## [0.9.0] - 2023-04-11
 ### Changed
 - Params in block / define are analysed in the same way as they are defined by developer - they are no longer optional with default value `null` 

--- a/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
@@ -73,7 +73,7 @@ final class AddParametersForBlockNodeVisitor extends NodeVisitorAbstract
             for ($i = 0; $i < count($parameters[0]); $i++) {
                 /** @var string|null $defaultValue */
                 $defaultValue = $parameters['default'][$i] ?: null;
-                if ($defaultValue !== null && str_starts_with('\'', $defaultValue)) {
+                if ($defaultValue !== null && str_starts_with($defaultValue, '\'')) {
                     $default = new String_(trim($defaultValue, '\''));
                 } elseif (is_numeric($defaultValue)) {
                     if (str_contains($defaultValue, '.')) {

--- a/src/Error/Transformer/BlockParameterErrorTransformer.php
+++ b/src/Error/Transformer/BlockParameterErrorTransformer.php
@@ -13,10 +13,14 @@ final class BlockParameterErrorTransformer implements ErrorTransformerInterface
     public function transform(Error $error): Error
     {
         preg_match(self::BLOCK_METHOD, $error->getMessage(), $match);
-        if (isset($match['block']) && strpos($error->getMessage(), 'MissingBlockParameter') === false) {
+        if (isset($match['block'])) {
             $block = lcfirst(str_replace('_', '-', $match['block']));
-            $message = ucfirst(str_replace($match[0], 'block ' . $block, $error->getMessage()));
-            $error->setMessage($message);
+            $message = $error->getMessage();
+            // replace method name to block name
+            $message = str_replace($match[0], 'block ' . $block, $message);
+            // replace fake `MissingBlockParameter` with `none` type
+            $message = str_replace('MissingBlockParameter', 'none', $message);
+            $error->setMessage(ucfirst($message));
         }
         return $error;
     }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/define.latte
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/define.latte
@@ -13,5 +13,6 @@
 {include my-block 'paramObject' => $knownObject, 'paramString' => $knownString, 'paramNullable' => null, 'paramNoType' => $knownString, 'paramFloat' => $knownFloat, 'paramInteger' => $knownInteger, 'paramArray' => $knownArray}
 {include my-block 'paramObject' => $knownString, 'paramString' => $knownInteger}
 {include my-block $knownString, $knownInteger, 'paramInteger' => $knownInteger}
+{include my-block}
 
 {php \PhpStan\dumpType($paramString)}

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -278,6 +278,11 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'define.latte',
             ],
             [
+                'Block my-block invoked with 2 parameters, 4-9 required.',
+                14,
+                'define.latte',
+            ],
+            [
                 'Parameter #1 $paramObject of block my-block expects stdClass, string given.',
                 14,
                 'define.latte',
@@ -295,11 +300,21 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
             [
                 'Parameter #2 $paramString of block my-block expects string, int given.',
                 15,
+                'define.latte',
+            ],
+            [
+                'Parameter #3 $paramNullable of block my-block expects string|null, none given.',
+                15,
+                'define.latte',
+            ],
+            [
+                'Block my-block invoked with 0 parameters, 4-9 required.',
+                16,
                 'define.latte',
             ],
             [
                 'Dumped type: \'some string\'',
-                17,
+                18,
                 'define.latte',
             ],
         ]);


### PR DESCRIPTION
- default value is used if it is available
- fixed string default values for blocks
- blocks called with no parameters are also transfered to method call

Resolves https://github.com/efabrica-team/phpstan-latte/issues/343