### PR TITLE
Removed tip about type of variable comming from PHPDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Improved processing of block's missing parameters - default value is used if it is available
 
+### Removed
+- Tip about type of variable comming from PHPDoc (all variable types in compiled templates are from PHPDoc, so this tip doesn't make sense)
+
 ### Fixed
 - String default values for blocks
 - Blocks called with no parameters are also transfered to method call

--- a/extension.neon
+++ b/extension.neon
@@ -202,6 +202,7 @@ services:
     - Efabrica\PHPStanLatte\Error\Transformer\UnknownTagErrorTransformer
     - Efabrica\PHPStanLatte\Error\Transformer\CallActionWithParametersMissingCorrespondingMethodErrorTransformer
     - Efabrica\PHPStanLatte\Error\Transformer\BlockParameterErrorTransformer
+    - Efabrica\PHPStanLatte\Error\Transformer\RemoveTipAboutPhpDocErrorTransformer
 
     errorFormatter.table!:
         class: Efabrica\PHPStanLatte\Error\TableErrorFormatter

--- a/src/Error/Transformer/RemoveTipAboutPhpDocErrorTransformer.php
+++ b/src/Error/Transformer/RemoveTipAboutPhpDocErrorTransformer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Error\Transformer;
+
+use Efabrica\PHPStanLatte\Error\Error;
+
+/**
+ * all variable types in compiled templates are from PHPDoc, so this tip doesn't make sense
+ */
+final class RemoveTipAboutPhpDocErrorTransformer implements ErrorTransformerInterface
+{
+    private const PHP_DOC_REGEX = '/Because the type is coming from a PHPDoc, you can turn off this check/';
+
+    public function transform(Error $error): Error
+    {
+        if ($error->getTip() === null) {
+            return $error;
+        }
+
+        if (preg_match(self::PHP_DOC_REGEX, $error->getTip()) === 1) {
+            $error->setTip(null);
+        }
+        return $error;
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -680,25 +680,21 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'Comparison operation ">" between 10 and 0 is always true.',
                 2,
                 'recursion.latte',
-                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Comparison operation ">" between 9 and 0 is always true.',
                 2,
                 'recursion.latte',
-                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Comparison operation ">" between 8 and 0 is always true.',
                 2,
                 'recursion.latte',
-                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Comparison operation ">" between 7 and 0 is always true.',
                 2,
                 'recursion.latte',
-                'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
             ],
             [
                 'Dumped type: 9',


### PR DESCRIPTION
all variable types in compiled templates are from PHPDoc, so this tip doesn't make sense