### PR TITLE
Unfreezed phpstan-nette extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.4 <8.3",
         "ext-json": "*",
         "phpstan/phpstan": "^1.10.6",
-        "phpstan/phpstan-nette": "1.2.6",
+        "phpstan/phpstan-nette": "^1.2.6",
         "latte/latte": "^2.11.6 | ^3.0.4",
         "nette/utils": "^3.2|^4.0",
         "nette/finder": "^2.5|^3.0"

--- a/src/Error/ErrorBuilder.php
+++ b/src/Error/ErrorBuilder.php
@@ -46,6 +46,7 @@ final class ErrorBuilder
         '/Method Nette\\\\Forms\\\\Controls\\\\BaseControl::getControlPart\(\) invoked with 1 parameter, 0 required\./', // dynamic checkbox is typehinted as BaseControl
         '/Instantiated class MissingBlockParameter not found\./', # missing block parameter palceholder
         '/Variable \$ʟ_it on left side of \?\? always exists and is not nullable\./', // $ʟ_it in try / catch in foreach is always set
+        '/Cannot call method render() on mixed\./', // redundant error for unknown components with phpstan-nette extension
     ];
 
     /** @var string[] */

--- a/src/Error/ErrorBuilder.php
+++ b/src/Error/ErrorBuilder.php
@@ -46,7 +46,7 @@ final class ErrorBuilder
         '/Method Nette\\\\Forms\\\\Controls\\\\BaseControl::getControlPart\(\) invoked with 1 parameter, 0 required\./', // dynamic checkbox is typehinted as BaseControl
         '/Instantiated class MissingBlockParameter not found\./', # missing block parameter palceholder
         '/Variable \$ʟ_it on left side of \?\? always exists and is not nullable\./', // $ʟ_it in try / catch in foreach is always set
-        '/Cannot call method render() on mixed\./', // redundant error for unknown components with phpstan-nette extension
+        '/Cannot call method render\(\) on mixed\./', // redundant error for unknown components with phpstan-nette extension
     ];
 
     /** @var string[] */


### PR DESCRIPTION
@MartinMystikJonas can you please handle these errors? I don't know if we should just ignore them, or we can create ReturnTypehint extension here in our extension and not use phpstan-nette's one.