### PR TITLE
Collect renders also from calls to Latte\Engine

### DIFF
--- a/src/LatteContext/Collector/TemplateRenderCollector.php
+++ b/src/LatteContext/Collector/TemplateRenderCollector.php
@@ -23,6 +23,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
+use PHPStan\Type\TypeCombinator;
 
 /**
  * @extends AbstractLatteContextCollector<CollectedTemplateRender|CollectedError>
@@ -137,7 +138,12 @@ final class TemplateRenderCollector extends AbstractLatteContextCollector
         }
 
         $calledType = $scope->getType($node->var);
-        if (!$this->templateTypeResolver->resolve($calledType)) {
+        if ($calledType instanceof ThisType) {
+            $calledType = $calledType->getStaticObjectType();
+        }
+        $calledType = TypeCombinator::removeNull($calledType);
+        $engineType = new ObjectType('Latte\Engine');
+        if (!$this->templateTypeResolver->resolve($calledType) && !$engineType->isSuperTypeOf($calledType)->yes()) {
             return null;
         }
 

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
@@ -80,6 +80,7 @@ final class CollectorResultForSimpleControlTest extends CollectorResultTest
             'TEMPLATE methodCall.ab.latte SomeControl::renderMethodCallMulti ["presenter","control","flashes"] []',
             'TEMPLATE methodCall.ba.latte SomeControl::renderMethodCallMulti ["presenter","control","flashes"] []',
             'TEMPLATE methodCall.bb.latte SomeControl::renderMethodCallMulti ["presenter","control","flashes"] []',
+            'TEMPLATE engine.latte SomeControl::renderRenderEngine ["presenter","control","flashes","a","b"] []',
         ]);
     }
 

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/SomeControl.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/SomeControl.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\SimpleControl\Fixtures\Resolve;
 
 use Exception;
+use Latte\Engine;
 use Nette\Application\UI\Control;
 
 final class SomeControl extends Control
@@ -204,5 +205,11 @@ final class SomeControl extends Control
     private function neverReturn(): void
     {
         die();
+    }
+
+    public function renderRenderEngine(): void
+    {
+        $engine = new Engine();
+        $engine->render(__DIR__ . '/engine.latte', ['a' => 'a', 'b' => 'b']);
     }
 }

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/engine.latte
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Resolve/engine.latte
@@ -1,0 +1,3 @@
+{$a}
+{$b}
+{$nonExistingVariable}

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -212,8 +212,13 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'throwSometimes.latte',
             ],
             [
+                'Variable $nonExistingVariable might not be defined.',
+                3,
+                'engine.latte',
+            ],
+            [
                 'Rendered latte template ' . __DIR__ . '/Fixtures/Resolve/error.latte does not exist.',
-                193,
+                194,
                 'SomeControl.php',
             ],
         ]);


### PR DESCRIPTION
Related to Slim framework use-case where renders are triggered by call to `$engine->renderToString()`