### PR TITLE
Added support for form fields in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- Support for form fields in containers
+
+### Fixed
+- Report errors when numeric container names are used in latte
+
 ## [0.13.0] - 2023-06-05
 ### Changed
 - Separated collection of Form Containers

--- a/docs/how_it_works.md
+++ b/docs/how_it_works.md
@@ -125,10 +125,95 @@ It is important to check the context first (text after path of latte file - rend
 
     Now the type of `$baz` will be `'bar'|null` and isset() in condition will be valid.
 
-<!-- TODO
-## Components
--->
 
-<!-- TODO
+## Components
+
+Components are collected from PHP classes (e.g. Presenters or Controls) when using one of these ways:
+
+1) class method createComponent()
+```php
+protected function createComponentSomething(): SomeControl
+{
+    return new SomeControl();
+}
+```
+ 
+2) calling method addComponent()
+```php
+public function actionDefault(): void
+{
+    $this->addComponent('something', new SomeControl());
+}
+```
+
+3) assign to $this:
+```php
+public function actionDefault(): void
+{
+    $this['something'] = new SomeControl();
+}
+```
+
+Subcomponents of components are also collected, so it is possible to use this:
+```latte
+{control someControl}
+{control someControl-header}
+{control someControl-body}
+```
+
+### Common errors
+
+#### Component with name "xxx" probably doesn't exist.
+First of all, check if your component is registered in Presenter / Control using one of way described above and if the name fits.
+
+
 ## Forms
--->
+
+Forms are collected from PHP classes (e.g. Presenters or Controls) when they are registered as components via `createComponent*` or `createComponent` method if this method returns instance of `Nette\Forms\Form`.
+Form fields and form containers are also collected and can be then analysed.
+
+**IMPORTANT NOTE**: Container fields are currently assigned to containers if the name of container is the same as the name of variable which adds some field to this container.  
+
+### Common errors
+
+#### Form control with name "xxx" probably does not exist.
+Let's say you register form like this:
+
+```php
+
+use Nette\Application\UI\Form;
+
+protected function createComponentContainerForm(): Form
+{
+    $form = new Form();
+    $form->setMethod('get');
+    $form->addCheckbox('checkbox', 'Checkbox');
+    $part1 = $form->addContainer('part1');
+    $part1->addText('text1', 'Text 1');
+    $part1->addSubmit('submit1', 'Submit 1');
+
+    $part2 = $form->addContainer('part2');
+    $part2->addText('text2', 'Text 2');
+    $part2->addSubmit('submit2', 'Submit 2');
+
+    return $form;
+}
+```
+
+
+
+Then you can access all registered fields in latte this way:
+```latte
+{form containerForm}
+    {$form[part1][text1]->getHtmlId()}
+    {input part1-text1}
+    {input part1-submit1}
+
+    {input part2-text2}
+    {input part2-submit2}
+
+    {input checkbox:}
+
+    {input xxx} <-- this field is not registered in createComponent method therefore it is marked as non-existing 
+{/form}
+```

--- a/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
@@ -190,6 +190,29 @@ final class AddFormClassesNodeVisitor extends NodeVisitorAbstract implements For
                 if ($formControlType instanceof ObjectType && ($formControlType->isInstanceOf('Nette\Forms\Controls\CheckboxList')->yes() || $formControlType->isInstanceOf('Nette\Forms\Controls\RadioList')->yes())) {
                     $this->possibleAlwaysTrueLabels[] = $this->findParentStmt($node);
                 }
+
+                /**
+                 * Replace:
+                 * <code>
+                 * $form['foo-bar']->getControl();
+                 * </code>
+                 *
+                 * With:
+                 * <code>
+                 * $form['foo']['bar']->getControl();
+                 * <code>
+                 *
+                 * if foobar exists in actual form
+                 */
+                if (str_contains($controlName, '-')) {
+                    $controlNameParts = explode('-', $controlName);
+                    $tmpDim = new ArrayDimFetch(new Variable('form'), new String_(array_shift($controlNameParts)));
+                    foreach ($controlNameParts as $controlNamePart) {
+                        $tmpDim = new ArrayDimFetch($tmpDim, new String_($controlNamePart));
+                    }
+                    $tmpDim->setAttributes($node->getAttributes());
+                    return $tmpDim;
+                }
             } elseif ($node->dim instanceof Variable) {
                 // dynamic control
             } else {

--- a/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
@@ -134,11 +134,8 @@ final class AddFormClassesNodeVisitor extends NodeVisitorAbstract implements For
                     $itemArgument = $node->getArgs()[0] ?? null;
                     $itemArgumentValue = $itemArgument ? $itemArgument->value : null;
 
-                    if ($itemArgumentValue instanceof String_) {
-                        $controlName = $itemArgumentValue->value;
-                        // TODO remove when container are supported
-                        $controlNameParts = explode('-', $controlName);
-                        $controlName = end($controlNameParts);
+                    if ($itemArgumentValue instanceof String_ || $itemArgumentValue instanceof LNumber) {
+                        $controlName = (string)$itemArgumentValue->value;
                         $formControl = $this->actualForm->getControl($controlName);
                         if ($formControl === null) {
                             $this->errorControlNodes[] = [
@@ -178,11 +175,8 @@ final class AddFormClassesNodeVisitor extends NodeVisitorAbstract implements For
                 return null;
             }
 
-            if ($node->dim instanceof String_) {
-                $controlName = $node->dim->value;
-                // TODO remove when container are supported
-                $controlNameParts = explode('-', $controlName);
-                $controlName = end($controlNameParts);
+            if ($node->dim instanceof String_ || $node->dim instanceof LNumber) {
+                $controlName = (string)$node->dim->value;
                 $formControl = $this->actualForm->getControl($controlName);
                 if ($formControl === null) {
                     $this->errorControlNodes[] = [

--- a/src/LatteContext/CollectedData/Form/CollectedFormControl.php
+++ b/src/LatteContext/CollectedData/Form/CollectedFormControl.php
@@ -16,14 +16,17 @@ final class CollectedFormControl extends CollectedLatteContextObject
 
     private ControlInterface $formControl;
 
+    private string $parentName;
+
     /**
      * @param class-string $className
      */
-    public function __construct(string $className, string $methodName, ControlInterface $formControl)
+    public function __construct(string $className, string $methodName, ControlInterface $formControl, string $parentName)
     {
         $this->className = $className;
         $this->methodName = $methodName;
         $this->formControl = $formControl;
+        $this->parentName = $parentName;
     }
 
     public function getClassName(): string
@@ -39,5 +42,10 @@ final class CollectedFormControl extends CollectedLatteContextObject
     public function getFormControl(): ControlInterface
     {
         return $this->formControl;
+    }
+
+    public function getParentName(): string
+    {
+        return $this->parentName;
     }
 }

--- a/src/LatteContext/Collector/FormControlCollector.php
+++ b/src/LatteContext/Collector/FormControlCollector.php
@@ -127,6 +127,7 @@ final class FormControlCollector extends AbstractLatteContextCollector
             return null;
         }
 
+        $parentName = $this->nameResolver->resolve($node->var) ?: 'form';
         $formControls = [];
         foreach ($controlNames as $controlName) {
             $controlName = (string)$controlName;
@@ -141,7 +142,8 @@ final class FormControlCollector extends AbstractLatteContextCollector
             $formControls[] = new CollectedFormControl(
                 $classReflection->getName(),
                 $methodName,
-                $formControl
+                $formControl,
+                $parentName
             );
         }
         return $formControls;

--- a/src/Template/Form/Behavior/ControlHolderBehavior.php
+++ b/src/Template/Form/Behavior/ControlHolderBehavior.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Template\Form\Behavior;
 
+use Efabrica\PHPStanLatte\Template\Form\ControlHolderInterface;
 use Efabrica\PHPStanLatte\Template\Form\ControlInterface;
 
 trait ControlHolderBehavior
@@ -21,13 +22,19 @@ trait ControlHolderBehavior
 
     public function getControl(string $name): ?ControlInterface
     {
-        return $this->controls[$name] ?? null;
+        $nameParts = explode('-', $name);
+        $controlName = array_shift($nameParts);
+        $control = $this->controls[$controlName] ?? null;
+        if ($control instanceof ControlHolderInterface && $nameParts !== []) {
+            return $control->getControl(implode('-', $nameParts));
+        }
+        return $control;
     }
 
     /**
      * @param ControlInterface[] $controls
      */
-    private function addControls(array $controls): void
+    public function addControls(array $controls): void
     {
         foreach ($controls as $control) {
             $this->controls[$control->getName()] = $control;

--- a/src/Template/Form/ControlHolderInterface.php
+++ b/src/Template/Form/ControlHolderInterface.php
@@ -10,4 +10,6 @@ interface ControlHolderInterface
      * @return ControlInterface[]
      */
     public function getControls(): array;
+
+    public function getControl(string $name): ?ControlInterface;
 }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Forms/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Forms/default.latte
@@ -58,6 +58,7 @@
 {form containerForm}
     {$form[part1][text1]->getHtmlId()}
     {input part1-text1}
+    {input part1-text2}
     {input part1-submit1}
 
     {input part2-text2}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -445,13 +445,28 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
+                'Form control with name "part1-text2" probably does not exist.',
+                61,
+                'default.latte',
+            ],
+            [
                 'Form control with name "5" probably does not exist.',
-                90,
+                87,
+                'default.latte',
+            ],
+            [
+                'Form control with name "5" probably does not exist.',
+                91,
                 'default.latte',
             ],
             [
                 'Form control with name "1" probably does not exist.',
-                108,
+                105,
+                'default.latte',
+            ],
+            [
+                'Form control with name "1" probably does not exist.',
+                109,
                 'default.latte',
             ],
         ]);


### PR DESCRIPTION
Collecting container fields to container based on its name and variable name.

This will work:
```php
protected function createComponentContainerForm(): Form
{
    $form = new Form();
    $container = $form->addContainer('container');
    $container->addText('text1', 'Text 1');
    $container->addText('text2', 'Text 2');
    return $form;
}
```

This will not work:
```php
protected function createComponentContainerForm(): Form
{
    $form = new Form();
    $foo = $form->addContainer('container');
    $foo->addText('text1', 'Text 1');
    $foo->addText('text2', 'Text 2');
    return $form;
}
```
because 'foo' !== 'container'