### PR TITLE
Removed empty string as 1st argument from method calls getControlPart() and getLabelPart()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Removed empty string as 1st argument from method calls getControlPart() and getLabelPart()
+
 ## [0.13.0] - 2023-06-05
 ### Changed
 - Separated collection of Form Containers

--- a/extension.neon
+++ b/extension.neon
@@ -151,6 +151,7 @@ services:
             - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\AddExtractParamsToTopNodeVisitor())
             - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\NotNullableSnippetDriverNodeVisitor())
             - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\ContainerArrayFetchChangeIntegerToStringNodeVisitor())
+            - addNodeVisitor(100, Efabrica\PHPStanLatte\Compiler\NodeVisitor\RemoveEmptyStringFromLabelAndControlPartNodeVisitor())
 
     # Link processors
     - Efabrica\PHPStanLatte\LinkProcessor\LinkProcessorFactory

--- a/src/Compiler/NodeVisitor/RemoveEmptyStringFromLabelAndControlPartNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/RemoveEmptyStringFromLabelAndControlPartNodeVisitor.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Compiler\NodeVisitor;
+
+use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ExprTypeNodeVisitorBehavior;
+use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ExprTypeNodeVisitorInterface;
+use Efabrica\PHPStanLatte\Resolver\NameResolver\NameResolver;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+
+final class RemoveEmptyStringFromLabelAndControlPartNodeVisitor extends NodeVisitorAbstract implements ExprTypeNodeVisitorInterface
+{
+    use ExprTypeNodeVisitorBehavior;
+
+    private NameResolver $nameResolver;
+
+    public function __construct(NameResolver $nameResolver)
+    {
+        $this->nameResolver = $nameResolver;
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (!$node instanceof MethodCall) {
+            return null;
+        }
+
+        if (!in_array($this->nameResolver->resolve($node), ['getControlPart', 'getLabelPart'], true)) {
+            return null;
+        }
+
+        $callerType = $this->getType($node->var);
+        if ($callerType === null) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $argValue = $args[0]->value;
+        if (!$argValue instanceof String_) {
+            return null;
+        }
+
+        if ($argValue->value === '') {
+            $node->args = [];
+        }
+
+        return $node;
+    }
+}

--- a/src/Error/ErrorBuilder.php
+++ b/src/Error/ErrorBuilder.php
@@ -44,10 +44,6 @@ final class ErrorBuilder
         '/Parameter #3 \$s of static method Latte\\\\Runtime\\\\Filters::convertTo\(\) expects string, mixed given\./', // latte 3 internal error
         '/Cannot call method addAttributes\(\) on Nette\\\\Utils\\\\Html\|string\./', // we will not test latte compiler itself
         '/Cannot call method addAttributes\(\) on Nette\\\\Utils\\\\Html\|null\./', // we will not test latte compiler itself
-        '/Method Nette\\\\Forms\\\\Controls\\\\BaseControl::getControlPart\(\) invoked with 1 parameter, 0 required\./', // dynamic checkbox is typehinted as BaseControl
-        '/Method Nette\\\\Forms\\\\Controls\\\\BaseControl::getLabelPart\(\) invoked with 1 parameter, 0 required\./', // dynamic checkbox is typehinted as BaseControl
-        '/Method Nette\\\\Forms\\\\Controls\\\\Checkbox::getControlPart\(\) invoked with 1 parameter, 0 required\./', // latte internal error - passing parameter (empty string) to getControlPart when {input checkbox:} is used
-        '/Method Nette\\\\Forms\\\\Controls\\\\Checkbox::getLabelPart\(\) invoked with 1 parameter, 0 required\./', // latte internal error - passing parameter (empty string) to getLabelPart when {label checkbox: /} is used
         '/Instantiated class MissingBlockParameter not found\./', # missing block parameter palceholder
         '/Variable \$ʟ_it on left side of \?\? always exists and is not nullable\./', // $ʟ_it in try / catch in foreach is always set
         '/Cannot call method render\(\) on mixed\./', // redundant error for unknown components with phpstan-nette extension

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Forms/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/templates/Forms/default.latte
@@ -7,8 +7,8 @@
 
 <form n:name="secondForm">
     {input select}
-    {input username}
-    {input password}
+    {input username:}{label username: /}
+    {input password:wrong}{label password:wrong /}
     {input checkbox}{label checkbox /} <label n:name="checkbox"><input n:name="checkbox">Checkbox</label>
     {label checkbox_list /}
     {input checkbox_list}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -420,6 +420,16 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
+                'Method Nette\Forms\Controls\BaseControl::getControlPart() invoked with 1 parameter, 0 required.',
+                11,
+                'default.latte',
+            ],
+            [
+                'Method Nette\Forms\Controls\BaseControl::getLabelPart() invoked with 1 parameter, 0 required.',
+                11,
+                'default.latte',
+            ],
+            [
                 'Form control with name "second_submit" probably does not exist.',
                 15,
                 'default.latte',


### PR DESCRIPTION
Resolves https://github.com/efabrica-team/phpstan-latte/issues/381

It fixes latte's wrong compilation of template where there is always added empty string as first argument when partial control rendering e.g. `{control checkbox:}` is used but will report wrong usage e.g. `{control checkbox:wrong}`