### PR TITLE
Support first class callable, failing test

### DIFF
--- a/.github/workflows/syntax_checker.yml
+++ b/.github/workflows/syntax_checker.yml
@@ -27,4 +27,26 @@ jobs:
           coverage: none # disable xdebug, pcov
 
       - name: Check syntax
-        run: find src tests -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
+        run: find src tests -name "*.php" ! -name "engine.bootstrap-firstClassCallableFilter.php" -print0 | xargs -0 -n1 -P8 php -l
+
+  syntax_checker-81plus:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.1', '8.2' ]
+
+    name: PHP syntax checker - PHP ${{ matrix.php }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none # disable xdebug, pcov
+
+      - name: Check syntax
+        run: find src tests -name "engine.bootstrap-firstClassCallableFilter.php" -print0 | xargs -0 -n1 -P8 php -l

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/FirstClassCallableFilterPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/FirstClassCallableFilterPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures;
+
+use Nette\Application\UI\Presenter;
+
+final class FirstClassCallableFilterPresenter extends Presenter
+{
+    public function actionDefault(): void
+    {
+        $this->template->title = 'title';
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/templates/FirstClassCallableFilter/default.latte
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/templates/FirstClassCallableFilter/default.latte
@@ -1,0 +1,1 @@
+{$title|objectFilterFirstClassCallable}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapFirstClassCallableFilterTest.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapFirstClassCallableFilterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
+
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+
+/**
+ * @requires PHP > 8.1
+ */
+final class LatteTemplatesRuleForEngineBootstrapFirstClassCallableFilterTest extends LatteTemplatesRuleTest
+{
+    protected static function additionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../../../../rules.neon',
+            __DIR__ . '/../../../config.neon',
+            __DIR__ . '/config-firstClassCallableFilter.neon',
+        ];
+    }
+
+    public function testFilters(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/FirstClassCallableFilterPresenter.php'], [
+        ]);
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/config-firstClassCallableFilter.neon
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/config-firstClassCallableFilter.neon
@@ -1,0 +1,5 @@
+parameters:
+    latte:
+        filters:
+            existingFilter: strlen
+        engineBootstrap: %rootDir%/../../../tests/Rule/LatteTemplatesRule/EngineBootstrap/engine.bootstrap-firstClassCallableFilter.php

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/engine.bootstrap-firstClassCallableFilter.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/engine.bootstrap-firstClassCallableFilter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
+
+use Latte\Engine;
+
+class FirstClassCallableFilters
+{
+    public function objectFilter(string $input): string
+    {
+        return $input;
+    }
+}
+
+$engine = new Engine();
+$engine->addFilter('objectFilterFirstClassCallable', (new FirstClassCallableFilters())->objectFilter(...));
+return $engine;


### PR DESCRIPTION
It will fail intentionally on PHP 8.0 and lower because the syntax is supported starting with PHP 8.1, that's expected, will see later if this test can be run only on 8.1+ and how.

But it will also fail on PHP 8.2 with "No closure found" which is not expected.
https://github.com/efabrica-team/phpstan-latte/actions/runs/5946401448/job/16126895022?pr=436#step:5:28

For #435