### PR TITLE
Fixed standalone presenter action template is not analysed if presenter dir and template dir are siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Standalone presenter action template is not analysed if presenter dir and template dir are siblings
+
 ## [0.16.0] - 2023-08-24
 ### Changed
 - All compiled templates from one run will be stored in one directory within tmpDir

--- a/src/LatteTemplateResolver/AbstractClassStandaloneTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractClassStandaloneTemplateResolver.php
@@ -53,6 +53,7 @@ abstract class AbstractClassStandaloneTemplateResolver extends AbstractClassTemp
             return [];
         }
 
+        $dir = $this->adjustDir($dir);
         $patterns = $this->getTemplatePathPatterns($reflectionClass, $dir);
 
         $standaloneTemplates = [];
@@ -74,6 +75,11 @@ abstract class AbstractClassStandaloneTemplateResolver extends AbstractClassTemp
         }
 
         return $standaloneTemplates;
+    }
+
+    protected function adjustDir(string $dir): string
+    {
+        return $dir;
     }
 
     /**

--- a/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenterStandalone.php
+++ b/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenterStandalone.php
@@ -27,12 +27,15 @@ final class NetteApplicationUIPresenterStandalone extends AbstractClassStandalon
         $shortClassName = $reflectionClass->getShortName();
         $presenterName = str_replace('Presenter', '', $shortClassName);
 
-        $dir = is_dir("$dir/templates") ? $dir : dirname($dir);
-
         return [
              $dir . '/templates/' . $presenterName . '/([a-zA-Z0-9_]+).latte',
              $dir . '/templates/' . $presenterName . '\.([a-zA-Z0-9_]+).latte',
         ];
+    }
+
+    protected function adjustDir(string $dir): string
+    {
+        return is_dir("$dir/templates") ? $dir : dirname($dir);
     }
 
     protected function isStandaloneTemplate(ReflectionClass $reflectionClass, string $templateFile, array $matches): bool

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/Presenters/BarBarPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/Presenters/BarBarPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithModule\Fixtures\Modules\Bar\Presenters;
+
+use Nette\Application\UI\Presenter;
+
+final class BarBarPresenter extends Presenter
+{
+    public function renderDefault(): void
+    {
+        $this->template->title = 'Bar bar default';
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/Presenters/BarFooPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/Presenters/BarFooPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithModule\Fixtures\Modules\Bar\Presenters;
+
+use Nette\Application\UI\Presenter;
+
+final class BarFooPresenter extends Presenter
+{
+    public function renderDefault(): void
+    {
+        $this->template->title = 'Bar foo default';
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarBar/add.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarBar/add.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarBar/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarBar/default.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarFoo/add.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarFoo/add.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarFoo/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Bar/templates/BarFoo/default.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/Presenters/FooBarPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/Presenters/FooBarPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithModule\Fixtures\Modules\Foo\Presenters;
+
+use Nette\Application\UI\Presenter;
+
+final class FooBarPresenter extends Presenter
+{
+    public function renderDefault(): void
+    {
+        //
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/Presenters/FooFooPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/Presenters/FooFooPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithModule\Fixtures\Modules\Foo\Presenters;
+
+use Nette\Application\UI\Presenter;
+
+final class FooFooPresenter extends Presenter
+{
+    public function renderDefault(): void
+    {
+        //
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooBar/add.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooBar/add.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooBar/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooBar/default.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooFoo/add.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooFoo/add.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooFoo/default.latte
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures/Modules/Foo/templates/FooFoo/default.latte
@@ -1,0 +1,3 @@
+{block content}
+
+<h1>{$title}</h1>

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/LatteTemplatesRuleForPresenterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithModule;
+
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+
+final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
+{
+    protected static function additionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../../../../rules.neon',
+            __DIR__ . '/../../../config.neon',
+            __DIR__ . '/config.neon',
+            __DIR__ . '/mapping.neon',
+        ];
+    }
+
+    public function testStandalone(): void
+    {
+        $this->analyse([
+            __DIR__ . '/Fixtures/Modules/Bar/Presenters/BarBarPresenter.php',
+            __DIR__ . '/Fixtures/Modules/Bar/Presenters/BarFooPresenter.php',
+            __DIR__ . '/Fixtures/Modules/Foo/Presenters/FooBarPresenter.php',
+            __DIR__ . '/Fixtures/Modules/Foo/Presenters/FooFooPresenter.php',
+        ], [
+            [
+                'Undefined variable: $title',
+                3,
+                'add.latte',
+            ],
+            [
+                'Undefined variable: $title',
+                3,
+                'add.latte',
+            ],
+            [
+                'Undefined variable: $title',
+                3,
+                'default.latte',
+            ],
+            [
+                'Undefined variable: $title',
+                3,
+                'add.latte',
+            ],
+            [
+                'Undefined variable: $title',
+                3,
+                'default.latte',
+            ],
+            [
+                'Undefined variable: $title',
+                3,
+                'add.latte',
+            ],
+        ]);
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/config.neon
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/config.neon
@@ -1,0 +1,5 @@
+parameters:
+    latte:
+        collectedPaths:
+            - tests/Rule/LatteTemplatesRule/PresenterWithModule/Fixtures
+            - tests/Rule/LatteTemplatesRule/PresenterWithModule/Source

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/mapping.neon
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/mapping.neon
@@ -1,0 +1,4 @@
+parameters:
+    latte:
+        applicationMapping:
+            *: Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithModule\Fixtures\Modules\*\Presenters\*Presenter


### PR DESCRIPTION
Resolves https://github.com/efabrica-team/phpstan-latte/issues/442