### PR TITLE
Add tests that should alert on `{$enum}` in templates, but passes

### DIFF
--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/EnumSomething.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/EnumSomething.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures;
+
+enum EnumSomething: string
+{
+
+    case Foo = 'FOO';
+
+}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/EnumsPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/EnumsPresenter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures;
+
+use Nette\Application\UI\Presenter;
+
+
+final class EnumsPresenter extends Presenter
+{
+    public function actionDefault(): void
+    {
+        $this->template->enum = EnumSomething::Foo();
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/templates/Enums/default.latte
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/templates/Enums/default.latte
@@ -1,0 +1,4 @@
+{$enum}
+{$enum->value}
+{\Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures\EnumSomething::Bar}
+{\Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures\EnumSomething::Bar->value}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapEnumsTest.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapEnumsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
+
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+
+/**
+ * @requires PHP > 8.1
+ */
+final class LatteTemplatesRuleForEngineBootstrapEnumsTest extends LatteTemplatesRuleTest
+{
+    protected static function additionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../../../../rules.neon',
+            __DIR__ . '/../../../config.neon',
+            __DIR__ . '/config.neon',
+        ];
+    }
+
+    public function testFilters(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/EnumsPresenter.php'], [
+            [
+                'Object of class Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures\EnumSomething could not be converted to string',
+                1,
+                'default.latte',
+            ],
+            [
+                'Object of class Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures\EnumSomething could not be converted to string',
+                3,
+                'default.latte',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Today I was changing some constants to enums, and `{$enum}` in a template fails with "Object of ... could not be converted to string" but this extension doesn't support it yet, so I thought I'd create a (failing) test at least.
