### PR TITLE
Fixed functions handling with FunctionExecutor in new Latte and removed unformatPresenterClass of new PresenterFactory

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.0', '8.1', '8.2', '8.3' ]
-        outdated-args: [ '--ignore=phpunit/phpunit' ]
+        outdated-args: ['--ignore=phpunit/phpunit --ignore=nikic/php-parser']
         include:
           - php: '7.4'
-            outdated-args: '--ignore=nette/finder --ignore=phpunit/phpunit'
+            outdated-args: '--ignore=nette/finder --ignore=phpunit/phpunit --ignore=nikic/php-parser'
 
     name: Composer outdated - PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "phpunit/phpunit": "^9.5",
         "nette/application": "^3.1.6",
         "nette/forms": "^3.1.12",
-        "nikic/php-parser": "^4.15",
+        "nikic/php-parser": "^4.19",
         "efabrica/coding-standard": "^0.6",
         "phpstan/phpstan-strict-rules": "^1.4",
         "spaze/phpstan-disallowed-calls": "^2.11 | ^3.0"

--- a/src/Compiler/Compiler/AbstractCompiler.php
+++ b/src/Compiler/Compiler/AbstractCompiler.php
@@ -42,6 +42,7 @@ abstract class AbstractCompiler implements CompilerInterface
         $this->strictMode = $strictMode;
         $this->filters = $filters;
         $this->functions = $functions;
+        $this->installFunctions($functions);
     }
 
     public function generateClassName(): string
@@ -93,6 +94,23 @@ abstract class AbstractCompiler implements CompilerInterface
         $providers['coreExceptionHandler'] = new CallableType($coreExceptionHandlerParameters, new VoidType());
         $phpContent .= $this->generateTypes($className . '_global', $providers);
         return $phpContent;
+    }
+
+    /**
+     * @param array<string, string|array{string, string}> $functions
+     */
+    private function installFunctions(array $functions): void
+    {
+        foreach ($functions as $name => $function) {
+            if (is_callable($function)) {
+                $this->engine->addFunction($name, $function);
+            } else {
+                // add placeholder function
+                $this->engine->addFunction($name, function (...$args) {
+                    return null;
+                });
+            }
+        }
     }
 
     abstract protected function createDefaultEngine(): Engine;

--- a/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
@@ -510,7 +510,7 @@ final class AddFormClassesNodeVisitor extends NodeVisitorAbstract implements For
                 ->setReturnType('?Nette\Forms\ControlGroup');
 
             $getGroupComment = $this->createGetGroupConditionalReturnTypeComment($controlHolder->getGroups());
-            $getGroupMethod->setDocComment('/** ' . $getGroupComment . ' */');
+            $getGroupMethod->setDocComment('/** @param int|string $name' . "\n" . $getGroupComment . ' */');
             $methods[] = $getGroupMethod;
         }
 

--- a/src/LinkProcessor/FakePresenterFactory.php
+++ b/src/LinkProcessor/FakePresenterFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\LinkProcessor;
+
+use Nette\Application\PresenterFactory;
+use Nette\InvalidStateException;
+
+final class FakePresenterFactory extends PresenterFactory
+{
+    /** @var array<string, array{string, string, string}> */
+    private array $mapping = [];
+
+    /**
+     * @param array<string, string|array{string, string}|array{string, string, string}> $mapping
+     */
+    public function setFakeMapping(array $mapping): FakePresenterFactory
+    {
+        parent::setMapping($mapping);
+        foreach ($mapping as $module => $mask) {
+            if (is_string($mask)) {
+                if (!preg_match('#^\\\\?([\w\\\\]*\\\\)?(\w*\*\w*?\\\\)?([\w\\\\]*\*\w*)$#D', $mask, $m)) {
+                    throw new InvalidStateException("Invalid mapping mask '$mask'.");
+                }
+
+                $this->mapping[$module] = [$m[1], $m[2] ?: '*Module\\', $m[3]];
+            } elseif (is_array($mask) && count($mask) === 3) {
+                $this->mapping[$module] = [$mask[0] ? $mask[0] . '\\' : '', $mask[1] . '\\', $mask[2]];
+            } else {
+                throw new InvalidStateException("Invalid mapping mask for module $module.");
+            }
+        }
+
+        return $this;
+    }
+
+    public function unformatPresenterClass(string $class): ?string
+    {
+        foreach ($this->mapping as $module => $mapping) {
+            $mapping = str_replace(['\\', '*'], ['\\\\', '(\w+)'], $mapping);
+            if (preg_match('#^\\\\?' . $mapping[0] . '((?:' . $mapping[1] . ')*)' . $mapping[2] . '$#Di', $class, $matches) !== 1) {
+                continue;
+            }
+
+            return ($module === '*' ? '' : $module . ':')
+              . preg_replace('#' . $mapping[1] . '#iA', '$1:', $matches[1]) . $matches[3];
+        }
+        return null;
+    }
+}

--- a/src/LinkProcessor/PresenterActionLinkProcessor.php
+++ b/src/LinkProcessor/PresenterActionLinkProcessor.php
@@ -77,6 +77,9 @@ final class PresenterActionLinkProcessor implements LinkProcessorInterface
                 if ($this->actualClass === null) {
                     return [];
                 }
+                if (!is_callable([$presenterFactory, 'unformatPresenterClass'])) {
+                    throw new LinkProcessorException('PresenterFactory does not have method unformatPresenterClass');
+                }
                 $actualClass = @$presenterFactory->unformatPresenterClass($this->actualClass);
                 if ($actualClass === null) {
                     return [];

--- a/src/LinkProcessor/PresenterFactoryFaker.php
+++ b/src/LinkProcessor/PresenterFactoryFaker.php
@@ -6,7 +6,6 @@ namespace Efabrica\PHPStanLatte\LinkProcessor;
 
 use InvalidArgumentException;
 use Nette\Application\IPresenterFactory;
-use Nette\Application\PresenterFactory;
 
 final class PresenterFactoryFaker
 {
@@ -38,8 +37,8 @@ final class PresenterFactoryFaker
                 throw new InvalidArgumentException('Presenter factory file must return instance of Nette\Application\IPresenterFactory');
             }
         } elseif ($this->mapping !== []) {
-            $presenterFactory = new PresenterFactory();
-            $presenterFactory->setMapping($this->mapping);
+            $presenterFactory = new FakePresenterFactory();
+            $presenterFactory->setFakeMapping($this->mapping);
         }
 
         $this->presenterFactory = $presenterFactory;

--- a/src/Rule/LatteTemplatesRule.php
+++ b/src/Rule/LatteTemplatesRule.php
@@ -120,7 +120,7 @@ final class LatteTemplatesRule implements Rule
         }
 
         $compiledTemplates = $this->compileTemplates($templates, $errors);
-        $errors = array_merge($errors, $this->analyseTemplates($compiledTemplates));
+        $errors = array_merge(array_filter($errors), $this->analyseTemplates($compiledTemplates));
 
         if (count($errors) > 1000) {
             $errors[] = RuleErrorBuilder::message('Too many errors in latte.')->build();
@@ -138,7 +138,7 @@ final class LatteTemplatesRule implements Rule
 
     /**
      * @param Template[] $templates
-     * @param RuleError[] $errors
+     * @param array<?RuleError> $errors
      * @param array<string, int> $alreadyAnalysedInParents
      * @return array<string, Template> path of compiled template => Template
      * @throws ShouldNotHappenException

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/FunctionsPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/FunctionsPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap\Fixtures;
+
+use Nette\Application\UI\Presenter;
+
+final class FunctionsPresenter extends Presenter
+{
+    public function actionDefault(): void
+    {
+        $this->template->title = 'title';
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/templates/Functions/default.latte
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Fixtures/templates/Functions/default.latte
@@ -1,0 +1,7 @@
+{=existingfunction()}
+{=nonexistingfunction()}
+{=closurefunction('foo')}
+{=closurefunctionwithintparam('foo')}
+{=closurefunctionwithstringparam('foo')}
+{=objectfunction('foo')}
+{=methodstringfunction('foo')}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapTest.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapTest.php
@@ -43,4 +43,25 @@ final class LatteTemplatesRuleForEngineBootstrapTest extends LatteTemplatesRuleT
             ],
         ]);
     }
+
+    public function testFunctions(): void
+    {
+        $this->analyse([__DIR__ . '/Fixtures/FunctionsPresenter.php'], [
+            [
+                'Function nonexistingfunction not found. ### Learn more at https://phpstan.org/user-guide/discovering-symbols',
+                2,
+                'default.latte',
+            ],
+            [
+                'Closure invoked with 1 parameter, 0 required.',
+                3,
+                'default.latte',
+            ],
+            [
+                'Parameter #1 $param of closure expects int, string given.',
+                4,
+                'default.latte',
+            ],
+        ]);
+    }
 }

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Source/Filters.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Source/Filters.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
+
+final class Filters
+{
+    public function objectFilter(string $input): string
+    {
+        return $input;
+    }
+
+    public static function methodFilter(string $input): string
+    {
+        return $input;
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/Source/Functions.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/Source/Functions.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
+
+final class Functions
+{
+    public function objectFunction(string $input): string
+    {
+        return $input;
+    }
+
+    public static function methodFunction(string $input): string
+    {
+        return $input;
+    }
+}

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/config.neon
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/config.neon
@@ -2,4 +2,6 @@ parameters:
     latte:
         filters:
             existingFilter: strlen
+        functions:
+            existingfunction: time
         engineBootstrap: %rootDir%/../../../tests/Rule/LatteTemplatesRule/EngineBootstrap/engine.bootstrap.php

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/engine.bootstrap.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/engine.bootstrap.php
@@ -6,18 +6,8 @@ namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
 
 use Latte\Engine;
 
-final class Filters
-{
-    public function objectFilter(string $input): string
-    {
-        return $input;
-    }
-
-    public static function methodFilter(string $input): string
-    {
-        return $input;
-    }
-}
+require_once __DIR__ . '/Source/Filters.php';
+require_once __DIR__ . '/Source/Functions.php';
 
 $engine = new Engine();
 $engine->addFilter('closure', function () {
@@ -28,4 +18,12 @@ $engine->addFilter('closureWithStringParam', function (string $param) {
 });
 $engine->addFilter('objectFilter', [new Filters(), 'objectFilter']);
 $engine->addFilter('methodStringFilter', Filters::class . '::methodFilter');
+$engine->addFunction('closurefunction', function () {
+});
+$engine->addFunction('closurefunctionwithintparam', function (int $param) {
+});
+$engine->addFunction('closurefunctionwithstringparam', function (string $param) {
+});
+$engine->addFunction('objectfunction', [new Functions(), 'objectFunction']);
+$engine->addFunction('methodstringfunction', Functions::class . '::methodFunction');
 return $engine;


### PR DESCRIPTION
Fisrt fix: In new Latte functions are not called directly but throught FunctionExecutor and Template is always passed as first parameter on call - FunctionExecutor then handles if it is passed to function or not based on type of first parameter (it is same principle used already for filters with FilterExecutor).

Second fix: New Nette removed unformatPresenterClass from PresenterFactory - we need to reimplement it in our FakePresenterFactory used to evaluate links. If user uses own PresenterFactory it would require to add implementation of unformatPresenterClass himself.

(In the future it would be best to replace implementation used here by https://github.com/MetisFW/phpstan-nette-links - I solved these issues more universaly there)

I also fixed some minor codiing standard and PHPStan errors.