### PR TITLE
Make Collector return type more explicit

### DIFF
--- a/src/Collector/Collector/AbstractCollector.php
+++ b/src/Collector/Collector/AbstractCollector.php
@@ -35,7 +35,7 @@ abstract class AbstractCollector implements Collector
 
     /**
      * @phpstan-param array<T> $items
-     * @return ?A[]
+     * @return non-empty-array<A>|null
      */
     protected function collectItems(array $items): ?array
     {

--- a/src/LatteContext/Collector/AbstractLatteContextCollector.php
+++ b/src/LatteContext/Collector/AbstractLatteContextCollector.php
@@ -35,7 +35,7 @@ abstract class AbstractLatteContextCollector
 
     /**
      * @param Node $node
-     * @phpstan-return null|array<T|CollectedError>
+     * @phpstan-return null|non-empty-array<T|CollectedError>
      */
     abstract public function collectData(Node $node, Scope $scope): ?array;
 }

--- a/src/LatteContext/Collector/FormCollector.php
+++ b/src/LatteContext/Collector/FormCollector.php
@@ -38,7 +38,7 @@ final class FormCollector extends AbstractLatteContextCollector
 
     /**
      * @param ClassMethod $node
-     * @phpstan-return null|CollectedForm[]
+     * @phpstan-return null|non-empty-array<CollectedForm>
      */
     public function collectData(Node $node, Scope $scope): ?array
     {
@@ -51,7 +51,7 @@ final class FormCollector extends AbstractLatteContextCollector
     }
 
     /**
-     * @phpstan-return null|CollectedForm[]
+     * @phpstan-return null|non-empty-array<CollectedForm>
      */
     private function findCreateComponent(ClassMethod $node, ClassReflection $classReflection, Scope $scope): ?array
     {

--- a/src/LatteContext/Collector/MethodReturnCollector.php
+++ b/src/LatteContext/Collector/MethodReturnCollector.php
@@ -21,7 +21,7 @@ final class MethodReturnCollector extends AbstractLatteContextCollector
 
     /**
      * @param Return_ $node
-     * @phpstan-return null|CollectedMethod[]
+     * @phpstan-return null|non-empty-array<CollectedMethod>
      */
     public function collectData(Node $node, Scope $scope): ?array
     {


### PR DESCRIPTION
while the previous return type was correct, it did not explicitly state/protect you from someone changing the collector and make it return a empty array.

thats a major problem which can happen, and I want to make sure this error will not bite you, like it did in my projects.

for in-detail context see https://github.com/phpstan/phpstan/discussions/11701#discussioncomment-10660711