### PR TITLE
Support for multiline {define} block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Updated coding standard (Possible **BC break** - added `final` or `abstract` to (almost) all classes)
 - Bleeding edge changes - updated typehints
+- Fixed parameters parsing for multiline {define}
 
 ## [0.16.3] - 2023-11-26
 ### Added

--- a/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
@@ -56,12 +56,12 @@ final class AddParametersForBlockNodeVisitor extends NodeVisitorAbstract
         }
 
         $parameters = [];
-        $pattern = '/(?<define>{define (?<block_name>.*?),? (?<parameters>.*)}) on line (?<line>\d+)/';
+        $pattern = '/(?<define>{define\s+(?<block_name>.*?)\s*,?\s+(?<parameters>.*)})\s+on line (?<line>\d+)/s';
         preg_match($pattern, $comment->getText(), $match);
         if (isset($match['parameters'])) {
             $define = $match['define'];
 
-            $typesAndVariablesPattern = '/(?<type>[\?\\\[\]\<\>[:alnum:]]*)[ ]*\$(?<variable>[[:alnum:]]+)/';
+            $typesAndVariablesPattern = '/(?<type>[\?\\\[\]\<\>[:alnum:]]*)[ ]*\$(?<variable>[[:alnum:]]+)/s';
             preg_match_all($typesAndVariablesPattern, $match['parameters'], $typesAndVariables);
 
             $variableTypes = array_combine($typesAndVariables['variable'], $typesAndVariables['type']) ?: [];
@@ -102,7 +102,7 @@ final class AddParametersForBlockNodeVisitor extends NodeVisitorAbstract
             }
         } else {
             // process default blocks content etc.
-            $pattern = '/{block (?<block_name>.*?)} on line (?<line>\d+)/';
+            $pattern = '/{block\s+(?<block_name>.*?)}\s+on line (?<line>\d+)/s';
             preg_match($pattern, $comment->getText(), $match);
         }
 

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/define.latte
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/Fixtures/Blocks/define.latte
@@ -29,4 +29,11 @@
 {include no-comma-block, $knownInteger}
 {include no-comma-block}
 
+{define multiline-block,
+  int $count,
+  string $name}
+    {php \PHPStan\dumpType($count)}
+    {php \PHPStan\dumpType($name)}
+{/define}
+
 {php \PHPStan\dumpType($paramString)}

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -379,8 +379,18 @@ final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTes
                 'define.latte',
             ],
             [
+                'Dumped type: int',
+                35,
+                'define.latte',
+            ],
+            [
+                'Dumped type: string',
+                36,
+                'define.latte',
+            ],
+            [
                 'Dumped type: \'some string\'',
-                32,
+                39,
                 'define.latte',
             ],
         ]);


### PR DESCRIPTION
Currently multile block definition with parameters was not processed correctly - definition and types of parameters was not added