### PR TITLE
Compatibility fixes for new versions of PHPStan and Nette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased][unreleased]
+### Fixed
+- Compatibility with new Latte versions
 
 ## [0.17.1] - 2024-07-18
 ### Updated

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "php": ">=7.4 <8.4",
         "ext-json": "*",
-        "ext-random": "*",
         "phpstan/phpstan": "^1.12.13",
         "phpstan/phpstan-nette": "^1.2.6",
         "latte/latte": "^2.11.6 | ^3.0.4",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php": ">=7.4 <8.4",
         "ext-json": "*",
-        "phpstan/phpstan": "^1.10.50",
+        "ext-random": "*",
+        "phpstan/phpstan": "^1.12.13",
         "phpstan/phpstan-nette": "^1.2.6",
         "latte/latte": "^2.11.6 | ^3.0.4",
         "nette/utils": "^3.2|^4.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -72,7 +72,7 @@ parameters:
             path: src/Compiler/Compiler/AbstractCompiler.php
 
         -
-            message: '#^Parameter \#1 \$value of static method PhpParser\\BuilderHelpers\:\:normalizeValue\(\) expects array\|bool\|float\|int\|PhpParser\\Node\\Expr\|string\|UnitEnum\|null, mixed given\.$#'
+            message: '#^Parameter \#1 \$value of static method PhpParser\\BuilderHelpers\:\:normalizeValue\(\) expects .*, mixed given\.$#'
             path: src/LinkProcessor/LinkParamsProcessor.php
         -
             messages:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -72,7 +72,7 @@ parameters:
             path: src/Compiler/Compiler/AbstractCompiler.php
 
         -
-            message: '#^Parameter \#1 \$value of static method PhpParser\\BuilderHelpers\:\:normalizeValue\(\) expects array\|bool\|float\|int\|PhpParser\\Node\\Expr\|string\|null, mixed given\.$#'
+            message: '#^Parameter \#1 \$value of static method PhpParser\\BuilderHelpers\:\:normalizeValue\(\) expects array\|bool\|float\|int\|PhpParser\\Node\\Expr\|string\|UnitEnum\|null, mixed given\.$#'
             path: src/LinkProcessor/LinkParamsProcessor.php
         -
             messages:
@@ -144,16 +144,6 @@ parameters:
             messages:
                 - '#^Although PHPStan\\Node\\InClassNode is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
                 - '#^Although PHPStan\\Node\\ClassMethod is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
-
-        -
-            messages:
-                -'#^Although PHPStan\\Rules\\MetadataRuleError is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
-                -'#^Although PHPStan\\Rules\\FileRuleError is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
-                -'#^Although PHPStan\\Rules\\LineRuleError is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
-                -'#^Although PHPStan\\Rules\\TipRuleError is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
-                -'#^Although PHPStan\\Rules\\IdentifierRuleError is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
-                -'#^Although PHPStan\\Rules\\NonIgnorableRuleError is covered by backward compatibility promise, this instanceof assumption might break because it''s not guaranteed to always stay the same\.$#'
-            path: src/Error/ErrorBuilder.php
 
         # to be done later, no idea how to fix it now
         -

--- a/src/Analyser/LatteContextAnalyser.php
+++ b/src/Analyser/LatteContextAnalyser.php
@@ -104,7 +104,11 @@ final class LatteContextAnalyser
                         try {
                             $collectedData = $collector->collectData($node, $scope);
                         } catch (Throwable $e) {
-                            $fileErrors[] = RuleErrorBuilder::message(get_class($collector) . ' error: ' . $e->getMessage())->file($file)->line($node->getLine())->build();
+                            $fileErrors[] = RuleErrorBuilder::message(get_class($collector) . ' error: ' . $e->getMessage())
+                                ->identifier('latte.collectorError')
+                                ->file($file)
+                                ->line($node->getLine())
+                                ->build();
                             continue;
                         }
                         if ($collectedData === null || $collectedData === []) {
@@ -116,12 +120,21 @@ final class LatteContextAnalyser
                 $scope = $this->scopeFactory->create(ScopeContext::create($file));
                 $this->nodeScopeResolver->processNodes($parserNodes, $scope, $nodeCallback);
             } catch (Throwable $e) {
-                $fileErrors[] = RuleErrorBuilder::message('LatteContextAnalyser error: ' . $e->getMessage())->file($file)->build();
+                $fileErrors[] = RuleErrorBuilder::message('LatteContextAnalyser error: ' . $e->getMessage())
+                    ->identifier('latte.failed')
+                    ->file($file)
+                    ->build();
             }
         } elseif (is_dir($file)) {
-            $fileErrors[] = RuleErrorBuilder::message(sprintf('File %s is a directory.', $file))->file($file)->build();
+            $fileErrors[] = RuleErrorBuilder::message(sprintf('File %s is a directory.', $file))
+                ->identifier('latte.fileError')
+                ->file($file)
+                ->build();
         } else {
-            $fileErrors[] = RuleErrorBuilder::message(sprintf('File %s does not exist.', $file))->file($file)->build();
+            $fileErrors[] = RuleErrorBuilder::message(sprintf('File %s does not exist.', $file))
+                ->identifier('latte.fileError')
+                ->file($file)
+                ->build();
         }
         return new LatteContextData($fileCollectedData, $fileErrors);
     }

--- a/src/Analyser/LatteContextData.php
+++ b/src/Analyser/LatteContextData.php
@@ -6,12 +6,12 @@ namespace Efabrica\PHPStanLatte\Analyser;
 
 use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedError;
 use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedLatteContextObject;
-use PHPStan\Rules\RuleError;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 final class LatteContextData
 {
-    /** @var array<RuleError> */
+    /** @var list<IdentifierRuleError> */
     private array $errors;
 
     /** @var array<CollectedLatteContextObject> */
@@ -22,7 +22,7 @@ final class LatteContextData
 
     /**
      * @param array<CollectedLatteContextObject> $collectedData
-     * @param array<RuleError> $errors
+     * @param list<IdentifierRuleError> $errors
      */
     public function __construct(array $collectedData, array $errors)
     {
@@ -34,7 +34,7 @@ final class LatteContextData
     }
 
     /**
-     * @return array<RuleError>
+     * @return list<IdentifierRuleError>
      */
     public function getErrors(): array
     {
@@ -42,13 +42,17 @@ final class LatteContextData
     }
 
     /**
-     * @return array<RuleError>
+     * @return list<IdentifierRuleError>
      */
     public function getCollectedErrors(): array
     {
         $errors = [];
         foreach ($this->getCollectedData(CollectedError::class) as $collectedError) {
-            $errors[] = RuleErrorBuilder::message($collectedError->getMessage())->file($collectedError->getFile())->line($collectedError->getLine() ?? -1)->build();
+            $errors[] = RuleErrorBuilder::message($collectedError->getMessage())
+                ->identifier('latte.error')
+                ->file($collectedError->getFile())
+                ->line($collectedError->getLine() ?? -1)
+                ->build();
         }
         return $errors;
     }

--- a/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
@@ -58,7 +58,7 @@ final class AddParametersForBlockNodeVisitor extends NodeVisitorAbstract
         $parameters = [];
         $pattern = '/(?<define>{define\s+(?<block_name>.*?)\s*,?\s+(?<parameters>.*)})\s+on line (?<line>\d+)/s';
         preg_match($pattern, $comment->getText(), $match);
-        if (isset($match['parameters'])) {
+        if (isset($match['define']) && isset($match['block_name']) &&isset($match['parameters'])) {
             $define = $match['define'];
 
             $typesAndVariablesPattern = '/(?<type>[\?\\\[\]\<\>[:alnum:]]*)[ ]*\$(?<variable>[[:alnum:]]+)/s';

--- a/src/Compiler/NodeVisitor/LinkNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/LinkNodeVisitor.php
@@ -20,7 +20,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\NodeVisitorAbstract;
@@ -143,7 +143,7 @@ final class LinkNodeVisitor extends NodeVisitorAbstract implements ActualClassNo
         }
 
         return [
-            new If_(new Identical(new FuncCall(new Name('mt_rand')), new LNumber(0)), [
+            new If_(new Identical(new FuncCall(new Name('uniqid')), new String_('random')), [
                 'stmts' => $expressions,
             ], $attributes),
         ];

--- a/src/Error/ErrorBuilder.php
+++ b/src/Error/ErrorBuilder.php
@@ -15,7 +15,6 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\LineRuleError;
 use PHPStan\Rules\MetadataRuleError;
 use PHPStan\Rules\NonIgnorableRuleError;
-use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\TipRuleError;
 
@@ -52,6 +51,8 @@ final class ErrorBuilder
         '/PHPDoc tag @var for variable \$__variables__ has no value type specified in iterable type array\./', // fake variable $__variables__ can have not specified array type
         '/Cannot call method startTag\(\) on Nette\\\\Utils\\\\Html\|string\./', // nette/forms error https://github.com/nette/forms/issues/308
         '/Cannot call method endTag\(\) on Nette\\\\Utils\\\\Html\|string\./', // nette/forms error https://github.com/nette/forms/issues/308
+        '/Variable .* on left side of \?\?= is never defined./',
+        '/Variable .* on left side of \?\?= always exists and is not nullable./',
     ];
 
     /** @var string[] */
@@ -89,7 +90,7 @@ final class ErrorBuilder
 
     /**
      * @param Error[] $originalErrors
-     * @return RuleError[]
+     * @return IdentifierRuleError[]
      */
     public function buildErrors(array $originalErrors, string $templatePath, ?string $compiledTemplatePath, ?string $context = null): array
     {
@@ -110,7 +111,7 @@ final class ErrorBuilder
         return $errors;
     }
 
-    public function buildError(Error $originalError, string $templatePath, ?string $compiledTemplatePath, ?string $context = null): ?RuleError
+    public function buildError(Error $originalError, string $templatePath, ?string $compiledTemplatePath, ?string $context = null): ?IdentifierRuleError
     {
         $lineMap = $compiledTemplatePath ? $this->lineMapper->getLineMap($compiledTemplatePath) : new LineMap();
 
@@ -119,6 +120,7 @@ final class ErrorBuilder
 
         $ruleErrorBuilder = RuleErrorBuilder::message($error->getMessage())
             ->file($templatePath)
+            ->identifier('latte.error')
             ->metadata(array_merge($originalError->getMetadata(), [
                 'context' => $context === '' ? null : $context,
                 'is_warning' => $this->isWarning($error->getMessage()),
@@ -138,8 +140,8 @@ final class ErrorBuilder
     }
 
     /**
-     * @param RuleError[] $ruleErrors
-     * @return RuleError[]
+     * @param IdentifierRuleError[] $ruleErrors
+     * @return list<IdentifierRuleError>
      */
     public function buildRuleErrors(array $ruleErrors): array
     {
@@ -182,7 +184,7 @@ final class ErrorBuilder
         return $newRuleErrors;
     }
 
-    private function errorSignature(RuleError $error): string
+    private function errorSignature(IdentifierRuleError $error): string
     {
         $values = (array)$error;
         unset($values['metadata']);

--- a/src/Error/ErrorBuilder.php
+++ b/src/Error/ErrorBuilder.php
@@ -53,6 +53,7 @@ final class ErrorBuilder
         '/Cannot call method endTag\(\) on Nette\\\\Utils\\\\Html\|string\./', // nette/forms error https://github.com/nette/forms/issues/308
         '/Variable .* on left side of \?\?= is never defined./',
         '/Variable .* on left side of \?\?= always exists and is not nullable./',
+        '/Property Latte\\\\Runtime\\\\Template::\$parentName .* does not accept mixed./',
     ];
 
     /** @var string[] */

--- a/src/Error/Transformer/BlockParameterErrorTransformer.php
+++ b/src/Error/Transformer/BlockParameterErrorTransformer.php
@@ -13,7 +13,7 @@ final class BlockParameterErrorTransformer implements ErrorTransformerInterface
     public function transform(Error $error): Error
     {
         preg_match(self::BLOCK_METHOD, $error->getMessage(), $match);
-        if (isset($match['block'])) {
+        if (isset($match[0]) && isset($match['block'])) {
             $block = lcfirst(str_replace('_', '-', $match['block']));
             $message = $error->getMessage();
             // replace method name to block name

--- a/src/LatteTemplateResolver/AbstractClassMethodTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractClassMethodTemplateResolver.php
@@ -35,6 +35,7 @@ abstract class AbstractClassMethodTemplateResolver extends AbstractClassTemplate
                     !$latteContext->methodFinder()->hasAnyAlwaysTerminated($reflectionClass->getName(), $reflectionMethod->getName())
                 ) {
                     $result->addErrorFromBuilder(RuleErrorBuilder::message("Cannot resolve latte template for {$reflectionClass->getShortName()}::{$reflectionMethod->getName()}().")
+                        ->identifier('latte.cannotResolve')
                         ->file($reflectionClass->getFileName() ?? 'unknown')
                         ->line($reflectionMethod->getStartLine()));
                 }

--- a/src/LatteTemplateResolver/LatteTemplateResolverResult.php
+++ b/src/LatteTemplateResolver/LatteTemplateResolverResult.php
@@ -7,7 +7,7 @@ namespace Efabrica\PHPStanLatte\LatteTemplateResolver;
 use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedTemplateRender;
 use Efabrica\PHPStanLatte\Template\Template;
 use Efabrica\PHPStanLatte\Template\TemplateContext;
-use PHPStan\Rules\RuleError;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 
 final class LatteTemplateResolverResult
@@ -15,12 +15,12 @@ final class LatteTemplateResolverResult
   /** @var array<string, Template>  */
     private array $templates = [];
 
-  /** @var RuleError[]  */
+  /** @var IdentifierRuleError[]  */
     private array $errors = [];
 
   /**
    * @param Template[] $templates
-   * @param RuleError[] $errors
+   * @param IdentifierRuleError[] $errors
    */
     public function __construct(array $templates = [], array $errors = [])
     {
@@ -39,7 +39,7 @@ final class LatteTemplateResolverResult
     }
 
   /**
-   * @return RuleError[]
+   * @return IdentifierRuleError[]
    */
     public function getErrors(): array
     {
@@ -51,11 +51,14 @@ final class LatteTemplateResolverResult
         $this->templates[$template->getSignatureHash()] = $template;
     }
 
-    public function addError(RuleError $error): void
+    public function addError(IdentifierRuleError $error): void
     {
         $this->errors[] = $error;
     }
 
+    /**
+     * @param RuleErrorBuilder<IdentifierRuleError> $error
+     */
     public function addErrorFromBuilder(RuleErrorBuilder $error): void
     {
         $this->errors[] = $error->build();
@@ -69,11 +72,13 @@ final class LatteTemplateResolverResult
         $templatePath = $templateRender->getTemplatePath();
         if ($templatePath === null) {
             $this->addErrorFromBuilder(RuleErrorBuilder::message('Cannot resolve rendered latte template.')
+                ->identifier('latte.cannotResolve')
                 ->file($templateRender->getFile())
                 ->line($templateRender->getLine()));
             return;
         } elseif (!is_file($templatePath)) {
             $this->addErrorFromBuilder(RuleErrorBuilder::message('Rendered latte template ' . $templatePath . ' does not exist.')
+                ->identifier('latte.notFound')
                 ->file($templateRender->getFile())
                 ->line($templateRender->getLine()));
             return;

--- a/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
+++ b/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
@@ -127,8 +127,9 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
             foreach ($actionDefinition['templatePaths'] as $template) {
                 if ($template === null) {
                     $result->addErrorFromBuilder(RuleErrorBuilder::message('Cannot automatically resolve latte template from expression.')
-                    ->file($reflectionClass->getFileName() ?? 'unknown')
-                    ->line($actionDefinition['line']));
+                        ->identifier('latte.cannotResolve')
+                        ->file($reflectionClass->getFileName() ?? 'unknown')
+                        ->line($actionDefinition['line']));
                     continue;
                 }
                 $result->addTemplate(new Template($template, $reflectionClass->getName(), $actionName, $actionDefinition['templateContext']));
@@ -143,6 +144,7 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
             if ($actionDefinition['defaultTemplate'] === null) {
                 if (!$actionDefinition['terminated'] && $actionDefinition['templatePaths'] === []) { // might not be rendered at all (for example redirect or use set template path)
                     $result->addErrorFromBuilder(RuleErrorBuilder::message("Cannot resolve latte template for action $actionName")
+                        ->identifier('latte.cannotResolve')
                         ->file($reflectionClass->getFileName() ?? 'unknown')
                         ->line($actionDefinition['line'])
                         ->identifier($actionName));

--- a/src/LinkProcessor/PresenterActionLinkProcessor.php
+++ b/src/LinkProcessor/PresenterActionLinkProcessor.php
@@ -69,8 +69,12 @@ final class PresenterActionLinkProcessor implements LinkProcessorInterface
             if (!$presenterFactory instanceof PresenterFactory) {
                 return [];
             }
-            $presenterClassName = $presenterFactory->formatPresenterClass($presenterWithModule);
-            if ($presenterClassName === '') {
+            if ($presenterWithModule) {
+                $presenterClassName = $presenterFactory->formatPresenterClass($presenterWithModule);
+            } else {
+                $presenterClassName = $this->actualClass;
+            }
+            if ($presenterClassName === '' || $presenterClassName === null) {
                 return [];
             }
             if (!$this->reflectionProvider->hasClass($presenterClassName)) {

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/VariablesPresenter.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/Fixtures/VariablesPresenter.php
@@ -52,7 +52,7 @@ final class VariablesPresenter extends ParentPresenter
         $this->template->someOtherVariableWithDefault = 'value from presenter';
 
         $this->template->nullOrUrl = null;
-        if (mt_rand()) {
+        if (uniqid() == 'random') {
             $this->template->nullOrUrl = 'https://example.org';
         }
     }

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -978,7 +978,7 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
         } else {
             $expectedErrors[] = [
                 'Syntax error, unexpected \')\'',
-                2,
+                -1,
                 'translate_new.latte',
             ];
 

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -866,12 +866,12 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
-                'Parameter #1 $ of closure expects string, int given.',
+                'Parameter #1 of closure expects string, int given.',
                 8,
                 'default.latte',
             ],
             [
-                'Parameter #2 $ of closure expects int, string given.',
+                'Parameter #2 of closure expects int, string given.',
                 8,
                 'default.latte',
             ],
@@ -881,12 +881,12 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
-                'Parameter #1 $ of closure expects string, int given.',
+                'Parameter #1 of closure expects string, int given.',
                 11,
                 'default.latte',
             ],
             [
-                'Parameter #2 $ of closure expects int, string given.',
+                'Parameter #2 of closure expects int, string given.',
                 11,
                 'default.latte',
             ],
@@ -896,12 +896,12 @@ final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
                 'default.latte',
             ],
             [
-                'Parameter #1 $ of callable callable(string, int): string expects string, int given.',
+                'Parameter #1 of callable callable(string, int): string expects string, int given.',
                 14,
                 'default.latte',
             ],
             [
-                'Parameter #2 $ of callable callable(string, int): string expects int, string given.',
+                'Parameter #2 of callable callable(string, int): string expects int, string given.',
                 14,
                 'default.latte',
             ],


### PR DESCRIPTION
I made some fixes for compatibility with new PHPStan and Nette,

There is still one error remaining for variables with default values I cannot solve. I am not sure if it is our unintended Latte behaviour. I recall @dg planned some changes to how `{default}` works.

Variable with defaut value:

```
{default $someVariableWithDefault = 'default value'}
```

 is now transformed to:

```php
$someVariableWithDefault ??= \array_key_exists('someVariableWithDefault', \get_defined_vars()) ? \null : 'default value';
```

So variable type is resolved to `'default value'|null` instead of `'default value'` as it was earlier.

We shuld also bump minimal PHPStan version for compatibility with new release.