### PR TITLE
Support PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "nette/finder": "^2.5|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5|^12.2",
         "nette/application": "^3.1.6",
         "nette/forms": "^3.1.12",
         "nikic/php-parser": "^5.5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,11 @@
             <directory suffix=".php">src/</directory>
         </include>
     </coverage>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
     <testsuites>
         <testsuite name="Test suite">
             <directory>tests/</directory>

--- a/tests/Resolver/ValueResolver/PathResolverTest.php
+++ b/tests/Resolver/ValueResolver/PathResolverTest.php
@@ -13,6 +13,7 @@ use PhpParser\ParserFactory;
 use PhpParser\PhpVersion;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class PathResolverTest extends PHPStanTestCase
 {
@@ -30,6 +31,7 @@ final class PathResolverTest extends PHPStanTestCase
     /**
      * @dataProvider fixtures
      */
+    #[DataProvider('fixtures')]
     public function testResolve(string $path): void
     {
         [$php, $output] = array_map('trim', explode('-----', file_get_contents($path)));
@@ -51,7 +53,7 @@ final class PathResolverTest extends PHPStanTestCase
         $this->assertEquals($output, $this->pathResolver->resolve($expression->expr, $scope));
     }
 
-    public function fixtures(): iterable
+    public static function fixtures(): iterable
     {
         foreach (Finder::findFiles('path.*.fixture')->in(__DIR__ . '/Fixtures') as $file) {
             yield [(string)$file];

--- a/tests/Resolver/ValueResolver/ValueResolverTest.php
+++ b/tests/Resolver/ValueResolver/ValueResolverTest.php
@@ -12,6 +12,7 @@ use PhpParser\ParserFactory;
 use PhpParser\PhpVersion;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ValueResolverTest extends PHPStanTestCase
 {
@@ -29,6 +30,7 @@ final class ValueResolverTest extends PHPStanTestCase
     /**
      * @dataProvider fixtures
      */
+    #[DataProvider('fixtures')]
     public function testResolve(string $path): void
     {
         [$php, $output] = array_map('trim', explode('-----', file_get_contents($path)));
@@ -50,7 +52,7 @@ final class ValueResolverTest extends PHPStanTestCase
         $this->assertEquals($output, $this->valueResolver->resolve($expression->expr, $scope));
     }
 
-    public function fixtures(): iterable
+    public static function fixtures(): iterable
     {
         foreach (Finder::findFiles('path.*.fixture')->in(__DIR__ . '/Fixtures') as $file) {
             yield [(string)$file];

--- a/tests/Rule/LatteTemplatesRule/Annotations/CollectorResultForAnnotationsTest.php
+++ b/tests/Rule/LatteTemplatesRule/Annotations/CollectorResultForAnnotationsTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\Annotations;
 
 use Nette\Utils\Finder;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-final class CollectorResultForAnnotationsTest extends ScanCollectorResultTest
+final class CollectorResultForAnnotationsTest extends ScanCollectorResultTestCase
 {
     protected static function additionalConfigFiles(): array
     {
@@ -19,6 +20,7 @@ final class CollectorResultForAnnotationsTest extends ScanCollectorResultTest
     /**
      * @dataProvider fixtures
      */
+    #[DataProvider('fixtures')]
     public function testFixture(string $fixtureName): void
     {
         $this->resolveFixture(
@@ -27,7 +29,7 @@ final class CollectorResultForAnnotationsTest extends ScanCollectorResultTest
         );
     }
 
-    public function fixtures(): array
+    public static function fixtures(): array
     {
         $fixtures = [];
         foreach (Finder::findDirectories('*')->in(__DIR__ . '/Fixtures') as $path) {

--- a/tests/Rule/LatteTemplatesRule/Annotations/LatteTemplateRuleForAnnotationsTest.php
+++ b/tests/Rule/LatteTemplatesRule/Annotations/LatteTemplateRuleForAnnotationsTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\Annotations;
 
 use Nette\Utils\Finder;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-final class LatteTemplateRuleForAnnotationsTest extends ScanLatteTemplatesRuleTest
+final class LatteTemplateRuleForAnnotationsTest extends ScanLatteTemplatesRuleTestCase
 {
     protected static function additionalConfigFiles(): array
     {
@@ -20,6 +21,7 @@ final class LatteTemplateRuleForAnnotationsTest extends ScanLatteTemplatesRuleTe
     /**
      * @dataProvider fixtures
      */
+    #[DataProvider('fixtures')]
     public function testFixture(string $fixtureName): void
     {
         $this->analyseFixture(
@@ -28,7 +30,7 @@ final class LatteTemplateRuleForAnnotationsTest extends ScanLatteTemplatesRuleTe
         );
     }
 
-    public function fixtures(): array
+    public static function fixtures(): array
     {
         $fixtures = [];
         foreach (Finder::findDirectories('*')->in(__DIR__ . '/Fixtures') as $path) {

--- a/tests/Rule/LatteTemplatesRule/Annotations/ScanCollectorResultTestCase.php
+++ b/tests/Rule/LatteTemplatesRule/Annotations/ScanCollectorResultTestCase.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\Annotations;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTestCase;
 use Nette\Utils\Finder;
 
-abstract class ScanCollectorResultTest extends CollectorResultTest
+abstract class ScanCollectorResultTestCase extends CollectorResultTestCase
 {
     private ExpectedErrorsScanner $expectedErrorsScanner;
 

--- a/tests/Rule/LatteTemplatesRule/Annotations/ScanLatteTemplatesRuleTestCase.php
+++ b/tests/Rule/LatteTemplatesRule/Annotations/ScanLatteTemplatesRuleTestCase.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\Annotations;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTestCase;
 use Nette\Utils\Finder;
 
-abstract class ScanLatteTemplatesRuleTest extends LatteTemplatesRuleTest
+abstract class ScanLatteTemplatesRuleTestCase extends LatteTemplatesRuleTestCase
 {
     private $expectedErrorsScanner;
 

--- a/tests/Rule/LatteTemplatesRule/CollectorResultTestCase.php
+++ b/tests/Rule/LatteTemplatesRule/CollectorResultTestCase.php
@@ -7,7 +7,7 @@ namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule;
 use PHPStan\Analyser\Error;
 use PHPStan\Rules\Rule;
 
-abstract class CollectorResultTest extends LatteTemplatesRuleTest
+abstract class CollectorResultTestCase extends LatteTemplatesRuleTestCase
 {
     protected function getRule(): Rule
     {

--- a/tests/Rule/LatteTemplatesRule/CustomLatteTemplateResolver/CollectorResultForCustomTemplateResolverTest.php
+++ b/tests/Rule/LatteTemplatesRule/CustomLatteTemplateResolver/CollectorResultForCustomTemplateResolverTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CustomLatteTemplateResolver;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTestCase;
 
-final class CollectorResultForCustomTemplateResolverTest extends CollectorResultTest
+final class CollectorResultForCustomTemplateResolverTest extends CollectorResultTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapFirstClassCallableFilterTest.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapFirstClassCallableFilterTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTestCase;
 
 /**
  * @requires PHP > 8.1
  */
-final class LatteTemplatesRuleForEngineBootstrapFirstClassCallableFilterTest extends LatteTemplatesRuleTest
+final class LatteTemplatesRuleForEngineBootstrapFirstClassCallableFilterTest extends LatteTemplatesRuleTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapTest.php
+++ b/tests/Rule/LatteTemplatesRule/EngineBootstrap/LatteTemplatesRuleForEngineBootstrapTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\EngineBootstrap;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTestCase;
 
-final class LatteTemplatesRuleForEngineBootstrapTest extends LatteTemplatesRuleTest
+final class LatteTemplatesRuleForEngineBootstrapTest extends LatteTemplatesRuleTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/LatteTemplatesRuleTestCase.php
+++ b/tests/Rule/LatteTemplatesRule/LatteTemplatesRuleTestCase.php
@@ -10,7 +10,7 @@ use PHPStan\Analyser\Error;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
-abstract class LatteTemplatesRuleTest extends RuleTestCase
+abstract class LatteTemplatesRuleTestCase extends RuleTestCase
 {
     final public static function getAdditionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/PresenterWithModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithModule/LatteTemplatesRuleForPresenterTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithModule;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTestCase;
 
-final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
+final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/CollectorResultForPresenterTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTestCase;
 
-final class CollectorResultForPresenterTest extends CollectorResultTest
+final class CollectorResultForPresenterTest extends CollectorResultTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule;
 
 use Efabrica\PHPStanLatte\Compiler\LatteVersion;
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTestCase;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\LinksPresenter;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\VariablesPresenter;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Source\CustomFormRenderer;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Source\SomeControl;
 
-final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTest
+final class LatteTemplatesRuleForPresenterTest extends LatteTemplatesRuleTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterWithNoMappingTest.php
+++ b/tests/Rule/LatteTemplatesRule/PresenterWithoutModule/LatteTemplatesRuleForPresenterWithNoMappingTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTestCase;
 use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule\Fixtures\LinksPresenter;
 
-class LatteTemplatesRuleForPresenterWithNoMappingTest extends LatteTemplatesRuleTest
+class LatteTemplatesRuleForPresenterWithNoMappingTest extends LatteTemplatesRuleTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/CollectorResultForSimpleControlTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\PresenterWithoutModule;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\CollectorResultTestCase;
 
-final class CollectorResultForSimpleControlTest extends CollectorResultTest
+final class CollectorResultForSimpleControlTest extends CollectorResultTestCase
 {
     protected static function additionalConfigFiles(): array
     {

--- a/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
+++ b/tests/Rule/LatteTemplatesRule/SimpleControl/LatteTemplatesRuleForSimpleControlTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\SimpleControl;
 
-use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTest;
+use Efabrica\PHPStanLatte\Tests\Rule\LatteTemplatesRule\LatteTemplatesRuleTestCase;
 
-final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTest
+final class LatteTemplatesRuleForSimpleControlTest extends LatteTemplatesRuleTestCase
 {
     protected static function additionalConfigFiles(): array
     {


### PR DESCRIPTION
PHPUnit 9.5 is not EOL as of now, but let's be ready when it will be
https://phpunit.de/supported-versions.html

Changes:
- test classes can't be abstract (renamed the abstract test classes to `TestCase`s)
- data providers must be static methods
- data providers are referenced by using the `DataProvider` attribute