### PR TITLE
PHPStan reflections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,17 @@
 /composer.lock
 /.phpunit.result.cache
 /tmp
+.agents/.aiagents
+.agents/bin
+.agents/skills
+.agents/tasks
+.agents/plan
+.agents/completed
+.codex/config.toml
+.claude/settings.json
+.claude/settings.local.json
+.claude/skills
+.playwright
+.playwright-cli
+CLAUDE.md
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [unreleased]
 
+### Updated
+- Internaly uses PHPStan reflections only (**BC break**)
+
 ### Added
 - Support for PHP 8.5
 - use function to micro-optimize
 
 ## [0.19.0] - 2025-11-28
+
 ### Added
 - Check if value outputted in template (or escaped for output) can be converted to string
 - Support for PHP 8.4
@@ -31,7 +35,6 @@ This version should significantly improve performace of repeated runs.
 ## [0.17.1] - 2024-07-18
 ### Updated
 - Coding standard
-
 ### Fixed
 - RelatedFilesCollector collecting classes that were not present in vendor
 
@@ -283,10 +286,7 @@ This version should significantly improve performace of repeated runs.
     - Transform components to explicit calls
 - Error mapper for better DX
 
-[unreleased]: https://github.com/efabrica-team/phpstan-latte/compare/0.19.0...HEAD
-[0.19.0]: https://github.com/efabrica-team/phpstan-latte/compare/0.18.0...0.19.0
-[0.18.0]: https://github.com/efabrica-team/phpstan-latte/compare/0.17.2...0.18.0
-[0.17.2]: https://github.com/efabrica-team/phpstan-latte/compare/0.17.1...0.17.2
+[unreleased]: https://github.com/efabrica-team/phpstan-latte/compare/0.17.1...HEAD
 [0.17.1]: https://github.com/efabrica-team/phpstan-latte/compare/0.17.0...0.17.1
 [0.17.0]: https://github.com/efabrica-team/phpstan-latte/compare/0.16.3...0.17.0
 [0.16.3]: https://github.com/efabrica-team/phpstan-latte/compare/0.16.2...0.16.3

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -107,9 +107,10 @@ parameters:
 
         # Latte version conditions
         -
-            message: '#Comparison operation "(<|>|<=|>=)" between [0-9]{5} and [0-9]{5} is always (true|false).#'
+            messages:
+                - '#Comparison operation "(<|>|<=|>=)" between [0-9]{5} and [0-9]{5} is always (true|false).#'
+                - '#isLatte.*\(\) never returns (true|false) so the return type can be changed to (true|false).#'
             path: src/Compiler/LatteVersion.php
-
         # Errors cause by multiple latte compiler engines
         -
             messages:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -111,6 +111,7 @@ parameters:
                 - '#Comparison operation "(<|>|<=|>=)" between [0-9]{5} and [0-9]{5} is always (true|false).#'
                 - '#isLatte.*\(\) never returns (true|false) so the return type can be changed to (true|false).#'
             path: src/Compiler/LatteVersion.php
+            reportUnmatched: false
         # Errors cause by multiple latte compiler engines
         -
             messages:

--- a/src/Analyser/LatteContextCollectorRegistry.php
+++ b/src/Analyser/LatteContextCollectorRegistry.php
@@ -37,7 +37,7 @@ final class LatteContextCollectorRegistry
     {
         $nodeType = get_class($node);
         if (!isset($this->cache[$nodeType])) {
-            $parentNodeTypes = [$nodeType] + (array)class_parents($nodeType) + (array)class_implements($nodeType);
+            $parentNodeTypes = [$nodeType] + (class_parents($nodeType) ?: []) + (class_implements($nodeType) ?: []);
             $collectors = [];
             foreach ($parentNodeTypes as $parentNodeType) {
                 foreach ($this->collectors[$parentNodeType] ?? [] as $collector) {

--- a/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddFormClassesNodeVisitor.php
@@ -491,7 +491,7 @@ final class AddFormClassesNodeVisitor extends NodeVisitorAbstract implements For
         $offsetGetComment = $this->createOffsetGetConditionalReturnTypeComment($parentClassName, $controlHolder->getControls());
 
         $offsetGetMethod = clone $baseOffsetGetMethod;
-        $offsetGetMethod->setDocComment('/** ' . $offsetGetComment . ' */');
+        $offsetGetMethod->setDocComment('/** @param string $name' . "\n" . $offsetGetComment . ' */');
 
         $methods = [
             $offsetGetMethod,

--- a/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/AddParametersForBlockNodeVisitor.php
@@ -65,8 +65,7 @@ final class AddParametersForBlockNodeVisitor extends NodeVisitorAbstract
 
         $parameters = [];
         $pattern = '/(?<define>{define\s+(?<block_name>.*?)\s*,?\s+(?<parameters>.*)})\s+on line (?<line>\d+)/s';
-        preg_match($pattern, $comment->getText(), $match);
-        if (isset($match['define']) && isset($match['block_name']) &&isset($match['parameters'])) {
+        if (preg_match($pattern, $comment->getText(), $match) === 1) {
             $define = $match['define'];
 
             $typesAndVariablesPattern = '/(?<type>[\?\\\[\]\<\>[:alnum:]]*)[ ]*\$(?<variable>[[:alnum:]]+)/s';

--- a/src/Compiler/NodeVisitor/Behavior/ComponentsNodeVisitorBehavior.php
+++ b/src/Compiler/NodeVisitor/Behavior/ComponentsNodeVisitorBehavior.php
@@ -76,7 +76,11 @@ trait ComponentsNodeVisitorBehavior
                     if ($part instanceof InterpolatedStringPart) {
                         $result[] = $part->value;
                     } else {
-                        $result[] = $this->evaluateComponentName($part);
+                        $value = $this->evaluateComponentName($part);
+                        if (!is_string($value)) {
+                            throw new ConstExprEvaluationException();
+                        }
+                        $result[] = $value;
                     }
                 }
                 return implode('', $result);

--- a/src/Compiler/NodeVisitor/ChangeFiltersNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/ChangeFiltersNodeVisitor.php
@@ -13,6 +13,7 @@ use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\FiltersNodeVisitorInterf
 use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ScopeNodeVisitorBehavior;
 use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ScopeNodeVisitorInterface;
 use Efabrica\PHPStanLatte\Template\Variable;
+use Efabrica\PHPStanLatte\Type\TypeHelper;
 use Latte\Runtime\FilterInfo;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
@@ -34,24 +35,17 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\VariadicPlaceholder;
 use PhpParser\NodeVisitorAbstract;
-use PHPStan\BetterReflection\BetterReflection;
-use PHPStan\BetterReflection\Reflection\ReflectionFunction as BetterReflectionFunction;
-use PHPStan\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
-use PHPStan\BetterReflection\Reflection\ReflectionNamedType as BetterReflectionNamedType;
-use PHPStan\BetterReflection\Reflection\ReflectionParameter as BetterReflectionParameter;
 use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ClosureTypeFactory;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
-use ReflectionFunction;
-use ReflectionNamedType;
-use ReflectionParameter;
 use function array_merge;
 use function explode;
 use function get_class;
@@ -247,7 +241,7 @@ final class ChangeFiltersNodeVisitor extends NodeVisitorAbstract implements Filt
 
         if ($filter instanceof Closure || $this->isCallableString($filter)) {
             if ($filter instanceof Closure) {
-                $args = $this->updateArgs(new ReflectionFunction($filter), $args);
+                $args = $this->updateArgs($this->closureTypeFactory->fromClosureObject($filter)->getCallableParametersAcceptors($this->getScope()), $args);
             }
             return new FuncCall(new VariableExpr($this->createFilterVariableName($filterName)), $args);
         }
@@ -256,7 +250,7 @@ final class ChangeFiltersNodeVisitor extends NodeVisitorAbstract implements Filt
             if (str_contains($filter, '::')) {
                 $filter = explode('::', $filter);
             } else {
-                $args = $this->updateArgs((new BetterReflection())->reflector()->reflectFunction($filter), $args);
+                $args = $this->updateArgs($this->reflectionProvider->getFunction(new FullyQualified($filter), null)->getVariants(), $args);
                 return new FuncCall(new FullyQualified($filter), $args);
             }
         }
@@ -270,15 +264,14 @@ final class ChangeFiltersNodeVisitor extends NodeVisitorAbstract implements Filt
         /** @var non-empty-string $methodName */
         $methodName = $filter[1];
 
-        $reflectionClass = (new BetterReflection())->reflector()->reflectClass($className);
-        $reflectionMethod = $reflectionClass->getMethod($methodName);
-
-        if ($reflectionMethod === null) {
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if (!$classReflection->hasNativeMethod($methodName)) {
             return null;
         }
+        $methodReflection = $classReflection->getNativeMethod($methodName);
 
-        $args = $this->updateArgs($reflectionMethod, $args);
-        if ($reflectionMethod->isStatic()) {
+        $args = $this->updateArgs($methodReflection->getVariants(), $args);
+        if ($methodReflection->isStatic()) {
             return new StaticCall(
                 new FullyQualified($className),
                 new Identifier($methodName),
@@ -295,21 +288,14 @@ final class ChangeFiltersNodeVisitor extends NodeVisitorAbstract implements Filt
     }
 
     /**
-     * @param BetterReflectionFunction|BetterReflectionMethod|ReflectionFunction $reflection
+     * @param ParametersAcceptor[] $parametersAcceptors
      * @param Arg[]|VariadicPlaceholder[] $args
      * @return Arg[]|VariadicPlaceholder[]
      */
-    private function updateArgs($reflection, array $args): array
+    private function updateArgs(array $parametersAcceptors, array $args): array
     {
-        $parameter = $reflection->getParameters()[0] ?? null;
-        if ($parameter instanceof BEtterReflectionParameter && $parameter->getType() instanceof BetterReflectionNamedType) {
-            $parameterType = $parameter->getType()->getName();
-        } elseif ($parameter instanceof ReflectionParameter && $parameter->getType() instanceof ReflectionNamedType) {
-            $parameterType = $parameter->getType()->getName();
-        } else {
-            $parameterType = null;
-        }
-        if ($parameterType === FilterInfo::class) {
+        $firstParameterTypeName = TypeHelper::getFirstParamTypeName($parametersAcceptors);
+        if ($firstParameterTypeName === FilterInfo::class) {
             $args = array_merge([
                 new Arg(new VariableExpr('ʟ_fi')),
             ], $args);

--- a/src/Compiler/NodeVisitor/ChangeFunctionsNodeVisitor.php
+++ b/src/Compiler/NodeVisitor/ChangeFunctionsNodeVisitor.php
@@ -14,6 +14,7 @@ use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ScopeNodeVisitorBehavior
 use Efabrica\PHPStanLatte\Compiler\NodeVisitor\Behavior\ScopeNodeVisitorInterface;
 use Efabrica\PHPStanLatte\Resolver\NameResolver\NameResolver;
 use Efabrica\PHPStanLatte\Template\Variable;
+use Efabrica\PHPStanLatte\Type\TypeHelper;
 use Latte\Runtime\Template;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
@@ -35,24 +36,17 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\VariadicPlaceholder;
 use PhpParser\NodeVisitorAbstract;
-use PHPStan\BetterReflection\BetterReflection;
-use PHPStan\BetterReflection\Reflection\ReflectionFunction as BetterReflectionFunction;
-use PHPStan\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
-use PHPStan\BetterReflection\Reflection\ReflectionNamedType as BetterReflectionNamedType;
-use PHPStan\BetterReflection\Reflection\ReflectionParameter as BetterReflectionParameter;
 use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\Reflection\MissingMethodFromReflectionException;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ClosureTypeFactory;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
-use ReflectionFunction;
-use ReflectionNamedType;
-use ReflectionParameter;
 use function array_merge;
 use function array_slice;
 use function explode;
@@ -256,7 +250,7 @@ final class ChangeFunctionsNodeVisitor extends NodeVisitorAbstract implements Fu
 
         if ($function instanceof Closure || $this->isCallableString($function)) {
             if ($function instanceof Closure) {
-                $args = $this->updateArgs(new ReflectionFunction($function), $args);
+                $args = $this->updateArgs($this->closureTypeFactory->fromClosureObject($function)->getCallableParametersAcceptors($this->getScope()), $args);
             }
             return new FuncCall(new VariableExpr($this->createFunctionVariableName($functionName)), $args);
         }
@@ -265,7 +259,7 @@ final class ChangeFunctionsNodeVisitor extends NodeVisitorAbstract implements Fu
             if (str_contains($function, '::')) {
                 $function = explode('::', $function);
             } else {
-                $args = $this->updateArgs((new BetterReflection())->reflector()->reflectFunction($function), $args);
+                $args = $this->updateArgs($this->reflectionProvider->getFunction(new FullyQualified($function), null)->getVariants(), $args);
                 return new FuncCall(new FullyQualified($function), $args);
             }
         }
@@ -279,15 +273,14 @@ final class ChangeFunctionsNodeVisitor extends NodeVisitorAbstract implements Fu
         /** @var non-empty-string $methodName */
         $methodName = $function[1];
 
-        $reflectionClass = (new BetterReflection())->reflector()->reflectClass($className);
-        $reflectionMethod = $reflectionClass->getMethod($methodName);
-
-        if ($reflectionMethod === null) {
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if (!$classReflection->hasNativeMethod($methodName)) {
             return null;
         }
+        $methodReflection = $classReflection->getNativeMethod($methodName);
 
-        $args = $this->updateArgs($reflectionMethod, $args);
-        if ($reflectionMethod->isStatic()) {
+        $args = $this->updateArgs($methodReflection->getVariants(), $args);
+        if ($methodReflection->isStatic()) {
             return new StaticCall(
                 new FullyQualified($className),
                 new Identifier($methodName),
@@ -304,21 +297,14 @@ final class ChangeFunctionsNodeVisitor extends NodeVisitorAbstract implements Fu
     }
 
     /**
-     * @param BetterReflectionFunction|BetterReflectionMethod|ReflectionFunction $reflection
+     * @param ParametersAcceptor[] $parametersAcceptors
      * @param Arg[]|VariadicPlaceholder[] $args
      * @return Arg[]|VariadicPlaceholder[]
      */
-    private function updateArgs($reflection, array $args): array
+    private function updateArgs(array $parametersAcceptors, array $args): array
     {
-        $parameter = $reflection->getParameters()[0] ?? null;
-        if ($parameter instanceof BetterReflectionParameter && $parameter->getType() instanceof BetterReflectionNamedType) {
-            $parameterType = $parameter->getType()->getName();
-        } elseif ($parameter instanceof ReflectionParameter && $parameter->getType() instanceof ReflectionNamedType) {
-            $parameterType = $parameter->getType()->getName();
-        } else {
-            $parameterType = null;
-        }
-        if ($parameterType !== Template::class &&
+        $firstParameterTypeName = TypeHelper::getFirstParamTypeName($parametersAcceptors);
+        if ($firstParameterTypeName !== Template::class &&
             isset($args[0]) &&
             $args[0] instanceof Arg &&
             $args[0]->value instanceof VariableExpr &&

--- a/src/Error/ErrorBuilder.php
+++ b/src/Error/ErrorBuilder.php
@@ -71,6 +71,8 @@ final class ErrorBuilder
         '/Only booleans are allowed in .* condition.*/',
         '/Parameter #1 \$s of static method Latte\\\\(Runtime|Essentials)\\\\Filters::escapeHtmlText\(\) expects .* mixed given\./',
         '/Cannot convert mixed to .*\./',
+        '/Call to function array_key_exists\(\) with .* will always evaluate to (true|false)\./',
+        '/Parameter #2 \$array of function implode expects array<string>, array<int, mixed> given\./', // n:class generates implode with mixed array
     ];
 
     /** @var string[] */

--- a/src/Error/Transformer/BlockParameterErrorTransformer.php
+++ b/src/Error/Transformer/BlockParameterErrorTransformer.php
@@ -16,8 +16,7 @@ final class BlockParameterErrorTransformer implements ErrorTransformerInterface
 
     public function transform(Error $error): Error
     {
-        preg_match(self::BLOCK_METHOD, $error->getMessage(), $match);
-        if (isset($match[0]) && isset($match['block'])) {
+        if (preg_match(self::BLOCK_METHOD, $error->getMessage(), $match) === 1) {
             $block = lcfirst(str_replace('_', '-', $match['block']));
             $message = $error->getMessage();
             // replace method name to block name

--- a/src/Error/Transformer/CallActionWithParametersMissingCorrespondingMethodErrorTransformer.php
+++ b/src/Error/Transformer/CallActionWithParametersMissingCorrespondingMethodErrorTransformer.php
@@ -14,8 +14,7 @@ final class CallActionWithParametersMissingCorrespondingMethodErrorTransformer i
 
     public function transform(Error $error): Error
     {
-        preg_match(self::CALL_ACTION_WITH_PARAMETERS_REGEX, $error->getMessage(), $match);
-        if (isset($match['presenter']) && isset($match['method'])) {
+        if (preg_match(self::CALL_ACTION_WITH_PARAMETERS_REGEX, $error->getMessage(), $match) === 1) {
             $message = 'Invalid link: Unable to pass parameters to "' . $match['presenter'] . '::' . $match['method'] . '()", missing corresponding method.';
             $tip = 'Add method action' . ucfirst($match['method']) . ' or render' . ucfirst($match['method']) . ' with corresponding parameters to presenter ' . $match['presenter'];
             $error->setMessage($message);

--- a/src/Error/Transformer/EscapeErrorTransformer.php
+++ b/src/Error/Transformer/EscapeErrorTransformer.php
@@ -14,9 +14,8 @@ final class EscapeErrorTransformer implements ErrorTransformerInterface
 
     public function transform(Error $error): Error
     {
-        preg_match(self::HTML_OUTPUT_REGEX, $error->getMessage(), $match);
-        if (isset($match[0]) && isset($match['type'])) {
-            $escape = Strings::upper($match['escape'] ?? '');
+        if (preg_match(self::HTML_OUTPUT_REGEX, $error->getMessage(), $match) === 1) {
+            $escape = Strings::upper($match['escape']);
             if ($escape === 'HTMLTEXT') {
                 $escape = 'HTML';
             }

--- a/src/LatteContext/Resolver/ClassLatteContextResolver.php
+++ b/src/LatteContext/Resolver/ClassLatteContextResolver.php
@@ -6,18 +6,18 @@ namespace Efabrica\PHPStanLatte\LatteContext\Resolver;
 
 use Efabrica\PHPStanLatte\LatteContext\LatteContext;
 use Efabrica\PHPStanLatte\Template\TemplateContext;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 
 class ClassLatteContextResolver implements LatteContextResolverInterface
 {
-    protected ReflectionClass $reflectionClass;
+    protected ClassReflection $classReflection;
 
     protected LatteContext $latteContext;
 
-    public function __construct(ReflectionClass $reflectionClass, LatteContext $latteContext)
+    public function __construct(ClassReflection $classReflection, LatteContext $latteContext)
     {
-        $this->reflectionClass = $reflectionClass;
+        $this->classReflection = $classReflection;
         $this->latteContext = $latteContext;
     }
 
@@ -56,7 +56,7 @@ class ClassLatteContextResolver implements LatteContextResolverInterface
      */
     protected function getClassName(): string
     {
-        return $this->reflectionClass->getName();
+        return $this->classReflection->getName();
     }
 
     protected function getClassType(): ObjectType

--- a/src/LatteTemplateResolver/AbstractClassMethodTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractClassMethodTemplateResolver.php
@@ -6,44 +6,45 @@ namespace Efabrica\PHPStanLatte\LatteTemplateResolver;
 
 use Efabrica\PHPStanLatte\LatteContext\CollectedData\CollectedTemplateRender;
 use Efabrica\PHPStanLatte\LatteContext\LatteContext;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\RuleErrorBuilder;
 use function array_filter;
 use function count;
 
 abstract class AbstractClassMethodTemplateResolver extends AbstractClassTemplateResolver
 {
-    protected function getClassResult(ReflectionClass $reflectionClass, LatteContext $latteContext): LatteTemplateResolverResult
+    protected function getClassResult(ClassReflection $classReflection, LatteContext $latteContext): LatteTemplateResolverResult
     {
-        if ($reflectionClass->isAbstract() || $reflectionClass->isAnonymous()) {
+        if ($classReflection->isAbstract() || $classReflection->isAnonymous()) {
             return new LatteTemplateResolverResult();
         }
 
         $result = new LatteTemplateResolverResult();
-        foreach ($this->getMethodsMatching($reflectionClass, $this->getClassMethodPattern() . 'i') as $reflectionMethod) {
-            if (!$reflectionMethod->isPublic()) {
+        foreach ($this->getMethodsMatching($classReflection, $this->getClassMethodPattern() . 'i') as $methodReflection) {
+            if (!$methodReflection->isPublic()) {
                 continue;
             }
-            $templateContext = $this->getClassGlobalTemplateContext($reflectionClass, $latteContext)
-                ->merge($latteContext->getMethodTemplateContext($reflectionClass->getName(), $reflectionMethod->getName()));
+            $methodName = $methodReflection->getName();
+            $templateContext = $this->getClassGlobalTemplateContext($classReflection, $latteContext)
+                ->merge($latteContext->getMethodTemplateContext($classReflection->getName(), $methodName));
 
-            $templateRenders = $latteContext->templateRenderFinder()->find($reflectionClass->getName(), $reflectionMethod->getName());
+            $templateRenders = $latteContext->templateRenderFinder()->find($classReflection->getName(), $methodName);
             $validTemplateRenders = array_filter($templateRenders, function (CollectedTemplateRender $templateRender) {
                 return $templateRender->getTemplatePath() !== null;
             });
             if (count($validTemplateRenders) === 0) {
-                if (!$latteContext->methodCallFinder()->hasAnyOutputCalls($reflectionClass->getName(), $reflectionMethod->getName()) &&
-                    !$latteContext->methodCallFinder()->hasAnyTerminatingCalls($reflectionClass->getName(), $reflectionMethod->getName()) &&
-                    !$latteContext->methodFinder()->hasAnyAlwaysTerminated($reflectionClass->getName(), $reflectionMethod->getName())
+                if (!$latteContext->methodCallFinder()->hasAnyOutputCalls($classReflection->getName(), $methodName) &&
+                    !$latteContext->methodCallFinder()->hasAnyTerminatingCalls($classReflection->getName(), $methodName) &&
+                    !$latteContext->methodFinder()->hasAnyAlwaysTerminated($classReflection->getName(), $methodName)
                 ) {
-                    $result->addErrorFromBuilder(RuleErrorBuilder::message("Cannot resolve latte template for {$reflectionClass->getShortName()}::{$reflectionMethod->getName()}().")
+                    $result->addErrorFromBuilder(RuleErrorBuilder::message("Cannot resolve latte template for {$classReflection->getNativeReflection()->getShortName()}::{$methodName}().")
                         ->identifier('latte.cannotResolve')
-                        ->file($reflectionClass->getFileName() ?? 'unknown')
-                        ->line($reflectionMethod->getStartLine()));
+                        ->file($classReflection->getFileName() ?? 'unknown')
+                        ->line($this->getMethodStartLine($classReflection, $methodName)));
                 }
             }
             foreach ($templateRenders as $templateRender) {
-                $result->addTemplateFromRender($templateRender, $templateContext, $reflectionClass->getName(), $reflectionMethod->getName());
+                $result->addTemplateFromRender($templateRender, $templateContext, $classReflection->getName(), $methodName);
             }
         }
         return $result;

--- a/src/LatteTemplateResolver/AbstractClassStandaloneTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractClassStandaloneTemplateResolver.php
@@ -9,7 +9,8 @@ use Efabrica\PHPStanLatte\PhpDoc\LattePhpDocResolver;
 use Efabrica\PHPStanLatte\Resolver\LayoutResolver\LayoutPathResolver;
 use Efabrica\PHPStanLatte\Template\Template;
 use Nette\Utils\Finder;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use SplFileInfo;
 use function preg_match;
 use function str_contains;
@@ -18,28 +19,28 @@ abstract class AbstractClassStandaloneTemplateResolver extends AbstractClassTemp
 {
     private LayoutPathResolver $layoutPathResolver;
 
-    public function __construct(LattePhpDocResolver $lattePhpDocResolver, LayoutPathResolver $layoutPathResolver)
+    public function __construct(LattePhpDocResolver $lattePhpDocResolver, ReflectionProvider $reflectionProvider, LayoutPathResolver $layoutPathResolver)
     {
-        parent::__construct($lattePhpDocResolver);
+        parent::__construct($lattePhpDocResolver, $reflectionProvider);
         $this->layoutPathResolver = $layoutPathResolver;
     }
 
-    protected function getClassResult(ReflectionClass $reflectionClass, LatteContext $latteContext): LatteTemplateResolverResult
+    protected function getClassResult(ClassReflection $classReflection, LatteContext $latteContext): LatteTemplateResolverResult
     {
         $result = new LatteTemplateResolverResult();
-        $standaloneTemplateFiles = $this->findStandaloneTemplates($reflectionClass);
+        $standaloneTemplateFiles = $this->findStandaloneTemplates($classReflection);
         foreach ($standaloneTemplateFiles as $standaloneTemplateFile) {
-            $templateContext = $this->getClassGlobalTemplateContext($reflectionClass, $latteContext);
+            $templateContext = $this->getClassGlobalTemplateContext($classReflection, $latteContext);
             $result->addTemplate(new Template(
                 $standaloneTemplateFile,
-                $reflectionClass->getName(),
+                $classReflection->getName(),
                 null,
                 $templateContext
             ));
 
             $layoutFilePath = $this->layoutPathResolver->resolve($standaloneTemplateFile);
             if ($layoutFilePath !== null) {
-                $result->addTemplate(new Template($layoutFilePath, $reflectionClass->getName(), null, $templateContext));
+                $result->addTemplate(new Template($layoutFilePath, $classReflection->getName(), null, $templateContext));
             }
         }
         return $result;
@@ -48,15 +49,15 @@ abstract class AbstractClassStandaloneTemplateResolver extends AbstractClassTemp
     /**
      * @return string[]
      */
-    protected function findStandaloneTemplates(ReflectionClass $reflectionClass): array
+    protected function findStandaloneTemplates(ClassReflection $classReflection): array
     {
-        $dir = $this->getClassDir($reflectionClass);
+        $dir = $this->getClassDir($classReflection);
         if ($dir === null) {
             return [];
         }
 
         $dir = $this->adjustDir($dir);
-        $patterns = $this->getTemplatePathPatterns($reflectionClass, $dir);
+        $patterns = $this->getTemplatePathPatterns($classReflection, $dir);
 
         $standaloneTemplates = [];
         /** @var SplFileInfo $file */
@@ -68,7 +69,7 @@ abstract class AbstractClassStandaloneTemplateResolver extends AbstractClassTemp
             foreach ($patterns as $pattern) {
                 $matches = [];
                 if (preg_match("#$pattern#", $file, $matches)) {
-                    if (!$this->isStandaloneTemplate($reflectionClass, $file, $matches)) {
+                    if (!$this->isStandaloneTemplate($classReflection, $file, $matches)) {
                         continue;
                     }
                     $standaloneTemplates[] = $file;
@@ -87,15 +88,15 @@ abstract class AbstractClassStandaloneTemplateResolver extends AbstractClassTemp
     /**
      * @return string[]
      */
-    abstract protected function getTemplatePathPatterns(ReflectionClass $reflectionClass, string $dir): array;
+    abstract protected function getTemplatePathPatterns(ClassReflection $classReflection, string $dir): array;
 
     /**
-     * @param ReflectionClass $reflectionClass
+     * @param ClassReflection $classReflection
      * @param string $templateFile
      * @param array<string|string[]> $patternMatches
      * @return bool
      */
-    protected function isStandaloneTemplate(ReflectionClass $reflectionClass, string $templateFile, array $patternMatches): bool
+    protected function isStandaloneTemplate(ClassReflection $classReflection, string $templateFile, array $patternMatches): bool
     {
         return true;
     }

--- a/src/LatteTemplateResolver/AbstractClassTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractClassTemplateResolver.php
@@ -17,11 +17,12 @@ use Efabrica\PHPStanLatte\Template\Variable;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
-use PHPStan\BetterReflection\BetterReflection;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
-use PHPStan\BetterReflection\Reflection\ReflectionMethod;
 use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
+use ReflectionException;
 use function dirname;
 use function preg_match;
 
@@ -31,9 +32,12 @@ abstract class AbstractClassTemplateResolver implements NodeLatteTemplateResolve
 
     private LattePhpDocResolver $lattePhpDocResolver;
 
-    public function __construct(LattePhpDocResolver $lattePhpDocResolver)
+    private ReflectionProvider $reflectionProvider;
+
+    public function __construct(LattePhpDocResolver $lattePhpDocResolver, ReflectionProvider $reflectionProvider)
     {
         $this->lattePhpDocResolver = $lattePhpDocResolver;
+        $this->reflectionProvider = $reflectionProvider;
     }
 
     public function collect(Node $node, Scope $scope): array
@@ -86,47 +90,57 @@ abstract class AbstractClassTemplateResolver implements NodeLatteTemplateResolve
     public function resolve(CollectedResolvedNode $resolvedNode, LatteContext $latteContext): LatteTemplateResolverResult
     {
         $className = $resolvedNode->getParam(self::PARAM_CLASS_NAME);
-        $reflectionClass = (new BetterReflection())->reflector()->reflectClass($className);
+        $classReflection = $this->reflectionProvider->getClass($className);
 
-        $fileName = $reflectionClass->getFileName();
+        $fileName = $classReflection->getFileName();
         if ($fileName === null) {
             return new LatteTemplateResolverResult();
         }
 
-        return $this->getClassResult($reflectionClass, $latteContext);
+        return $this->getClassResult($classReflection, $latteContext);
     }
 
     /**
-     * @return ReflectionMethod[]
+     * @return MethodReflection[]
      */
-    protected function getMethodsMatching(ReflectionClass $reflectionClass, string $pattern): array
+    protected function getMethodsMatching(ClassReflection $classReflection, string $pattern): array
     {
         $methods = [];
-        foreach ($this->getMethodsMatchingIncludingIgnored($reflectionClass, $pattern) as $reflectionMethod) {
-            if (!$this->lattePhpDocResolver->resolveForMethod($reflectionClass->getName(), $reflectionMethod->getName())->isIgnored()) {
-                $methods[] = $reflectionMethod;
+        foreach ($this->getMethodsMatchingIncludingIgnored($classReflection, $pattern) as $methodName) {
+            if (!$this->lattePhpDocResolver->resolveForMethod($classReflection->getName(), $methodName)->isIgnored()) {
+                $methods[] = $classReflection->getNativeMethod($methodName);
             }
         }
         return $methods;
     }
 
     /**
-     * @return ReflectionMethod[]
+     * @return string[]
      */
-    protected function getMethodsMatchingIncludingIgnored(ReflectionClass $reflectionClass, string $pattern): array
+    protected function getMethodsMatchingIncludingIgnored(ClassReflection $classReflection, string $pattern): array
     {
-        $methods = [];
-        foreach ($reflectionClass->getMethods() as $reflectionMethod) {
-            if (preg_match($pattern . 'i', $reflectionMethod->getName()) === 1) {
-                $methods[] = $reflectionMethod;
+        $methodNames = [];
+        foreach ($classReflection->getNativeReflection()->getMethods() as $nativeMethod) {
+            if (preg_match($pattern . 'i', $nativeMethod->getName()) === 1) {
+                $methodNames[] = $nativeMethod->getName();
             }
         }
-        return $methods;
+        return $methodNames;
     }
 
-    protected function getClassDir(ReflectionClass $reflectionClass): ?string
+    protected function getMethodStartLine(ClassReflection $classReflection, string $methodName): int
     {
-        $fileName = $reflectionClass->getFileName();
+        try {
+            $line = $classReflection->getNativeReflection()->getMethod($methodName)->getStartLine();
+            return $line !== false ? $line : -1;
+        } catch (ReflectionException $e) {
+            return -1;
+        }
+    }
+
+    protected function getClassDir(ClassReflection $classReflection): ?string
+    {
+        $fileName = $classReflection->getFileName();
         if ($fileName === null) {
             return null;
         }
@@ -146,50 +160,50 @@ abstract class AbstractClassTemplateResolver implements NodeLatteTemplateResolve
         return [];
     }
 
-    protected function getClassContextResolver(ReflectionClass $reflectionClass, LatteContext $latteContext): LatteContextResolverInterface
+    protected function getClassContextResolver(ClassReflection $classReflection, LatteContext $latteContext): LatteContextResolverInterface
     {
-        return new ClassLatteContextResolver($reflectionClass, $latteContext);
+        return new ClassLatteContextResolver($classReflection, $latteContext);
     }
 
     /**
      * @return Variable[]
      */
-    protected function getClassGlobalVariables(ReflectionClass $reflectionClass, LatteContext $latteContext): array
+    protected function getClassGlobalVariables(ClassReflection $classReflection, LatteContext $latteContext): array
     {
-        return $this->getClassContextResolver($reflectionClass, $latteContext)->getVariables();
+        return $this->getClassContextResolver($classReflection, $latteContext)->getVariables();
     }
 
     /**
      * @return Component[]
      */
-    protected function getClassGlobalComponents(ReflectionClass $reflectionClass, LatteContext $latteContext): array
+    protected function getClassGlobalComponents(ClassReflection $classReflection, LatteContext $latteContext): array
     {
-        return $this->getClassContextResolver($reflectionClass, $latteContext)->getComponents();
+        return $this->getClassContextResolver($classReflection, $latteContext)->getComponents();
     }
 
     /**
      * @return Form[]
      */
-    protected function getClassGlobalForms(ReflectionClass $reflectionClass, LatteContext $latteContext): array
+    protected function getClassGlobalForms(ClassReflection $classReflection, LatteContext $latteContext): array
     {
-        return $this->getClassContextResolver($reflectionClass, $latteContext)->getForms();
+        return $this->getClassContextResolver($classReflection, $latteContext)->getForms();
     }
 
     /**
      * @return Filter[]
      */
-    protected function getClassGlobalFilters(ReflectionClass $reflectionClass, LatteContext $latteContext): array
+    protected function getClassGlobalFilters(ClassReflection $classReflection, LatteContext $latteContext): array
     {
-        return $this->getClassContextResolver($reflectionClass, $latteContext)->getFilters();
+        return $this->getClassContextResolver($classReflection, $latteContext)->getFilters();
     }
 
-    protected function getClassGlobalTemplateContext(ReflectionClass $reflectionClass, LatteContext $latteContext): TemplateContext
+    protected function getClassGlobalTemplateContext(ClassReflection $classReflection, LatteContext $latteContext): TemplateContext
     {
         return new TemplateContext(
-            $this->getClassGlobalVariables($reflectionClass, $latteContext),
-            $this->getClassGlobalComponents($reflectionClass, $latteContext),
-            $this->getClassGlobalForms($reflectionClass, $latteContext),
-            $this->getClassGlobalFilters($reflectionClass, $latteContext)
+            $this->getClassGlobalVariables($classReflection, $latteContext),
+            $this->getClassGlobalComponents($classReflection, $latteContext),
+            $this->getClassGlobalForms($classReflection, $latteContext),
+            $this->getClassGlobalFilters($classReflection, $latteContext)
         );
     }
 
@@ -198,5 +212,5 @@ abstract class AbstractClassTemplateResolver implements NodeLatteTemplateResolve
         return '/.*/';
     }
 
-    abstract protected function getClassResult(ReflectionClass $resolveClass, LatteContext $latteContext): LatteTemplateResolverResult;
+    abstract protected function getClassResult(ClassReflection $classReflection, LatteContext $latteContext): LatteTemplateResolverResult;
 }

--- a/src/LatteTemplateResolver/AbstractClassTemplateResolver.php
+++ b/src/LatteTemplateResolver/AbstractClassTemplateResolver.php
@@ -106,26 +106,26 @@ abstract class AbstractClassTemplateResolver implements NodeLatteTemplateResolve
     protected function getMethodsMatching(ClassReflection $classReflection, string $pattern): array
     {
         $methods = [];
-        foreach ($this->getMethodsMatchingIncludingIgnored($classReflection, $pattern) as $methodName) {
-            if (!$this->lattePhpDocResolver->resolveForMethod($classReflection->getName(), $methodName)->isIgnored()) {
-                $methods[] = $classReflection->getNativeMethod($methodName);
+        foreach ($this->getMethodsMatchingIncludingIgnored($classReflection, $pattern) as $method) {
+            if (!$this->lattePhpDocResolver->resolveForMethod($classReflection->getName(), $method->getName())->isIgnored()) {
+                $methods[] = $method;
             }
         }
         return $methods;
     }
 
     /**
-     * @return string[]
+     * @return MethodReflection[]
      */
     protected function getMethodsMatchingIncludingIgnored(ClassReflection $classReflection, string $pattern): array
     {
-        $methodNames = [];
+        $methods = [];
         foreach ($classReflection->getNativeReflection()->getMethods() as $nativeMethod) {
             if (preg_match($pattern . 'i', $nativeMethod->getName()) === 1) {
-                $methodNames[] = $nativeMethod->getName();
+                $methods[] = $classReflection->getNativeMethod($nativeMethod->getName());
             }
         }
-        return $methodNames;
+        return $methods;
     }
 
     protected function getMethodStartLine(ClassReflection $classReflection, string $methodName): int

--- a/src/LatteTemplateResolver/Nette/NetteApplicationUIControl.php
+++ b/src/LatteTemplateResolver/Nette/NetteApplicationUIControl.php
@@ -8,7 +8,7 @@ use Efabrica\PHPStanLatte\LatteContext\LatteContext;
 use Efabrica\PHPStanLatte\LatteContext\Resolver\LatteContextResolverInterface;
 use Efabrica\PHPStanLatte\LatteContext\Resolver\Nette\NetteApplicationUIControlLatteContextResolver;
 use Efabrica\PHPStanLatte\LatteTemplateResolver\AbstractClassMethodTemplateResolver;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
+use PHPStan\Reflection\ClassReflection;
 
 final class NetteApplicationUIControl extends AbstractClassMethodTemplateResolver
 {
@@ -27,8 +27,8 @@ final class NetteApplicationUIControl extends AbstractClassMethodTemplateResolve
         return '/^render.*/';
     }
 
-    protected function getClassContextResolver(ReflectionClass $reflectionClass, LatteContext $latteContext): LatteContextResolverInterface
+    protected function getClassContextResolver(ClassReflection $classReflection, LatteContext $latteContext): LatteContextResolverInterface
     {
-        return new NetteApplicationUIControlLatteContextResolver($reflectionClass, $latteContext);
+        return new NetteApplicationUIControlLatteContextResolver($classReflection, $latteContext);
     }
 }

--- a/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
+++ b/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
@@ -14,8 +14,9 @@ use Efabrica\PHPStanLatte\PhpDoc\LattePhpDocResolver;
 use Efabrica\PHPStanLatte\Resolver\LayoutResolver\LayoutPathResolver;
 use Efabrica\PHPStanLatte\Template\Template;
 use Efabrica\PHPStanLatte\Template\TemplateContext;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
-use PHPStan\BetterReflection\Reflection\ReflectionMethod;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\RuleErrorBuilder;
 use function array_merge;
 use function count;
@@ -39,9 +40,9 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
 
     private LayoutPathResolver $layoutPathResolver;
 
-    public function __construct(LattePhpDocResolver $lattePhpDocResolver, LayoutPathResolver $layoutPathResolver)
+    public function __construct(LattePhpDocResolver $lattePhpDocResolver, ReflectionProvider $reflectionProvider, LayoutPathResolver $layoutPathResolver)
     {
-        parent::__construct($lattePhpDocResolver);
+        parent::__construct($lattePhpDocResolver, $reflectionProvider);
         $this->layoutPathResolver = $layoutPathResolver;
     }
 
@@ -50,14 +51,14 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
         return ['Nette\Application\UI\Presenter'];
     }
 
-    protected function getClassContextResolver(ReflectionClass $reflectionClass, LatteContext $latteContext): LatteContextResolverInterface
+    protected function getClassContextResolver(ClassReflection $classReflection, LatteContext $latteContext): LatteContextResolverInterface
     {
-        return new NetteApplicationUIPresenterLatteContextResolver($reflectionClass, $latteContext);
+        return new NetteApplicationUIPresenterLatteContextResolver($classReflection, $latteContext);
     }
 
-    protected function getClassResult(ReflectionClass $reflectionClass, LatteContext $latteContext): LatteTemplateResolverResult
+    protected function getClassResult(ClassReflection $classReflection, LatteContext $latteContext): LatteTemplateResolverResult
     {
-        if ($reflectionClass->isAbstract() || $reflectionClass->isAnonymous()) {
+        if ($classReflection->isAbstract() || $classReflection->isAnonymous()) {
             return new LatteTemplateResolverResult();
         }
 
@@ -65,42 +66,44 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
         $actions = [];
 
         // action methods - including matching render methods
-        foreach ($this->getMethodsMatching($reflectionClass, '/^action.*/') as $reflectionMethod) {
-            if (!$reflectionMethod->isPublic()) {
+        foreach ($this->getMethodsMatching($classReflection, '/^action.*/') as $methodReflection) {
+            if (!$methodReflection->isPublic()) {
                 continue;
             }
-            $actionName = lcfirst((string)preg_replace('/^action/i', '', $reflectionMethod->getName()));
+            $actionName = lcfirst((string)preg_replace('/^action/i', '', $methodReflection->getName()));
 
             if (!isset($actions[$actionName])) {
-                $actions[$actionName] = $this->createActionDefinition($reflectionClass, $latteContext, $actionName);
+                $actions[$actionName] = $this->createActionDefinition($classReflection, $latteContext, $actionName);
             }
-            $this->updateActionDefinitionByMethod($actions[$actionName], $reflectionClass, $reflectionMethod, $latteContext);
+            $this->updateActionDefinitionByMethod($actions[$actionName], $classReflection, $methodReflection, $latteContext);
 
             // alternative renders (changed by setView in startup or action* method)
             $setViewCalls = array_merge(
-                $latteContext->methodCallFinder()->findAllCalledOfType($reflectionClass->getName(), $reflectionMethod->getName(), self::CALL_SET_VIEW),
-                $latteContext->methodCallFinder()->findAllCalledOfType($reflectionClass->getName(), 'startup', self::CALL_SET_VIEW)
+                $latteContext->methodCallFinder()->findAllCalledOfType($classReflection->getName(), $methodReflection->getName(), self::CALL_SET_VIEW),
+                $latteContext->methodCallFinder()->findAllCalledOfType($classReflection->getName(), 'startup', self::CALL_SET_VIEW)
             );
             foreach ($setViewCalls as $setViewCall) {
                 $view = (string)$setViewCall->getParams()['view'];
                 $actionViewName = $actionName . "($view)";
                 $actions[$actionViewName] = $actions[$actionName];
-                $actions[$actionViewName]['defaultTemplate'] = $this->findDefaultTemplateFilePath($reflectionClass, $view);
-                $renderMethod = $reflectionClass->getMethod('render' . ucfirst($view));
-                if ($renderMethod !== null) {
-                    $this->updateActionDefinitionByMethod($actions[$actionViewName], $reflectionClass, $renderMethod, $latteContext);
+                $actions[$actionViewName]['defaultTemplate'] = $this->findDefaultTemplateFilePath($classReflection, $view);
+                $renderMethodName = 'render' . ucfirst($view);
+                if ($classReflection->hasNativeMethod($renderMethodName)) {
+                    $renderMethod = $classReflection->getNativeMethod($renderMethodName);
+                    $this->updateActionDefinitionByMethod($actions[$actionViewName], $classReflection, $renderMethod, $latteContext);
                 }
             }
 
             $alwaysSetViewCalls = array_merge(
-                $latteContext->methodCallFinder()->findAllAlwaysCalledOfType($reflectionClass->getName(), $reflectionMethod->getName(), self::CALL_SET_VIEW),
-                $latteContext->methodCallFinder()->findAllAlwaysCalledOfType($reflectionClass->getName(), 'startup', self::CALL_SET_VIEW)
+                $latteContext->methodCallFinder()->findAllAlwaysCalledOfType($classReflection->getName(), $methodReflection->getName(), self::CALL_SET_VIEW),
+                $latteContext->methodCallFinder()->findAllAlwaysCalledOfType($classReflection->getName(), 'startup', self::CALL_SET_VIEW)
             );
 
             if (count($alwaysSetViewCalls) === 0) {
-                $renderMethod = $reflectionClass->getMethod('render' . ucfirst($actionName));
-                if ($renderMethod !== null) {
-                    $this->updateActionDefinitionByMethod($actions[$actionName], $reflectionClass, $renderMethod, $latteContext);
+                $renderMethodName = 'render' . ucfirst($actionName);
+                if ($classReflection->hasNativeMethod($renderMethodName)) {
+                    $renderMethod = $classReflection->getNativeMethod($renderMethodName);
+                    $this->updateActionDefinitionByMethod($actions[$actionName], $classReflection, $renderMethod, $latteContext);
                 }
             } else {
                 unset($actions[$actionName]); // view is always changed
@@ -108,16 +111,16 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
         }
 
         // render methods without matching action method
-        foreach ($this->getMethodsMatching($reflectionClass, '/^render.*/') as $reflectionMethod) {
-            if (!$reflectionMethod->isPublic()) {
+        foreach ($this->getMethodsMatching($classReflection, '/^render.*/') as $methodReflection) {
+            if (!$methodReflection->isPublic()) {
                 continue;
             }
-            $actionName = lcfirst((string)preg_replace('/^render/i', '', $reflectionMethod->getName()));
+            $actionName = lcfirst((string)preg_replace('/^render/i', '', $methodReflection->getName()));
 
             if (!isset($actions[$actionName])) {
-                $actions[$actionName] = $this->createActionDefinition($reflectionClass, $latteContext, $actionName);
+                $actions[$actionName] = $this->createActionDefinition($classReflection, $latteContext, $actionName);
             }
-            $this->updateActionDefinitionByMethod($actions[$actionName], $reflectionClass, $reflectionMethod, $latteContext);
+            $this->updateActionDefinitionByMethod($actions[$actionName], $classReflection, $methodReflection, $latteContext);
         }
 
         $result = new LatteTemplateResolverResult();
@@ -125,11 +128,11 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
             // explicit render calls
             /** @var CollectedTemplateRender $templateRender */
             foreach ($actionDefinition['renders'] as $templateRender) {
-                $result->addTemplateFromRender($templateRender, $actionDefinition['templateContext'], $reflectionClass->getName(), $actionName);
+                $result->addTemplateFromRender($templateRender, $actionDefinition['templateContext'], $classReflection->getName(), $actionName);
 
                 $layoutFilePath = $this->layoutPathResolver->resolve($templateRender->getTemplatePath());
                 if ($layoutFilePath !== null) {
-                    $result->addTemplateFromRender($templateRender->withTemplatePath($layoutFilePath), $actionDefinition['templateContext'], $reflectionClass->getName(), $actionName);
+                    $result->addTemplateFromRender($templateRender->withTemplatePath($layoutFilePath), $actionDefinition['templateContext'], $classReflection->getName(), $actionName);
                 }
             }
 
@@ -138,15 +141,15 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
                 if ($template === null) {
                     $result->addErrorFromBuilder(RuleErrorBuilder::message('Cannot automatically resolve latte template from expression.')
                         ->identifier('latte.cannotResolve')
-                        ->file($reflectionClass->getFileName() ?? 'unknown')
+                        ->file($classReflection->getFileName() ?? 'unknown')
                         ->line($actionDefinition['line']));
                     continue;
                 }
-                $result->addTemplate(new Template($template, $reflectionClass->getName(), $actionName, $actionDefinition['templateContext']));
+                $result->addTemplate(new Template($template, $classReflection->getName(), $actionName, $actionDefinition['templateContext']));
 
                 $layoutFilePath = $this->layoutPathResolver->resolve($template);
                 if ($layoutFilePath !== null) {
-                    $result->addTemplate(new Template($layoutFilePath, $reflectionClass->getName(), $actionName, $actionDefinition['templateContext']));
+                    $result->addTemplate(new Template($layoutFilePath, $classReflection->getName(), $actionName, $actionDefinition['templateContext']));
                 }
             }
 
@@ -155,17 +158,17 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
                 if (!$actionDefinition['terminated'] && $actionDefinition['templatePaths'] === []) { // might not be rendered at all (for example redirect or use set template path)
                     $result->addErrorFromBuilder(RuleErrorBuilder::message("Cannot resolve latte template for action $actionName")
                         ->identifier('latte.cannotResolve')
-                        ->file($reflectionClass->getFileName() ?? 'unknown')
+                        ->file($classReflection->getFileName() ?? 'unknown')
                         ->line($actionDefinition['line'])
                         ->identifier($actionName));
                 }
                 continue;
             }
-            $result->addTemplate(new Template($actionDefinition['defaultTemplate'], $reflectionClass->getName(), $actionName, $actionDefinition['templateContext']));
+            $result->addTemplate(new Template($actionDefinition['defaultTemplate'], $classReflection->getName(), $actionName, $actionDefinition['templateContext']));
 
             $layoutFilePath = $this->layoutPathResolver->resolve($actionDefinition['defaultTemplate']);
             if ($layoutFilePath !== null) {
-                $result->addTemplate(new Template($layoutFilePath, $reflectionClass->getName(), $actionName, $actionDefinition['templateContext']));
+                $result->addTemplate(new Template($layoutFilePath, $classReflection->getName(), $actionName, $actionDefinition['templateContext']));
             }
         }
 
@@ -175,13 +178,13 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
     /**
      * @phpstan-return ActionDefinition
      */
-    private function createActionDefinition(ReflectionClass $reflectionClass, LatteContext $latteContext, string $actionName): array
+    private function createActionDefinition(ClassReflection $classReflection, LatteContext $latteContext, string $actionName): array
     {
         return [
-            'templateContext' => $this->getClassGlobalTemplateContext($reflectionClass, $latteContext),
+            'templateContext' => $this->getClassGlobalTemplateContext($classReflection, $latteContext),
             'line' => -1,
             'renders' => [],
-            'defaultTemplate' => $this->findDefaultTemplateFilePath($reflectionClass, $actionName),
+            'defaultTemplate' => $this->findDefaultTemplateFilePath($classReflection, $actionName),
             'templatePaths' => [],
             'terminated' => false,
         ];
@@ -190,21 +193,22 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
     /**
      * @phpstan-param ActionDefinition $actionDefinition
      */
-    private function updateActionDefinitionByMethod(&$actionDefinition, ReflectionClass $reflectionClass, ReflectionMethod $reflectionMethod, LatteContext $latteContext): void
+    private function updateActionDefinitionByMethod(&$actionDefinition, ClassReflection $classReflection, MethodReflection $methodReflection, LatteContext $latteContext): void
     {
-        $actionDefinition['templateContext'] = $actionDefinition['templateContext']->union($latteContext->getMethodTemplateContext($reflectionClass->getName(), $reflectionMethod->getName()));
-        $actionDefinition['line'] = $reflectionMethod->getStartLine();
-        $actionDefinition['renders'] = array_merge($actionDefinition['renders'], $latteContext->templateRenderFinder()->find($reflectionClass->getName(), $reflectionMethod->getName()));
-        $actionDefinition['templatePaths'] = array_merge($actionDefinition['templatePaths'], $latteContext->templatePathFinder()->find($reflectionClass->getName(), $reflectionMethod->getName()));
-        $actionDefinition['terminated'] = $actionDefinition['terminated'] || $latteContext->methodCallFinder()->hasAlwaysTerminatingCalls($reflectionClass->getName(), $reflectionMethod->getName());
-        $actionDefinition['terminated'] = $actionDefinition['terminated'] || $latteContext->methodFinder()->isAlwaysTerminated($reflectionClass->getName(), $reflectionMethod->getName());
+        $methodName = $methodReflection->getName();
+        $actionDefinition['templateContext'] = $actionDefinition['templateContext']->union($latteContext->getMethodTemplateContext($classReflection->getName(), $methodName));
+        $actionDefinition['line'] = $this->getMethodStartLine($classReflection, $methodName);
+        $actionDefinition['renders'] = array_merge($actionDefinition['renders'], $latteContext->templateRenderFinder()->find($classReflection->getName(), $methodName));
+        $actionDefinition['templatePaths'] = array_merge($actionDefinition['templatePaths'], $latteContext->templatePathFinder()->find($classReflection->getName(), $methodName));
+        $actionDefinition['terminated'] = $actionDefinition['terminated'] || $latteContext->methodCallFinder()->hasAlwaysTerminatingCalls($classReflection->getName(), $methodName);
+        $actionDefinition['terminated'] = $actionDefinition['terminated'] || $latteContext->methodFinder()->isAlwaysTerminated($classReflection->getName(), $methodName);
     }
 
-    private function findDefaultTemplateFilePath(ReflectionClass $reflectionClass, string $actionName): ?string
+    private function findDefaultTemplateFilePath(ClassReflection $classReflection, string $actionName): ?string
     {
-        $shortClassName = $reflectionClass->getShortName();
+        $shortClassName = $classReflection->getNativeReflection()->getShortName();
         $presenterName = str_replace('Presenter', '', $shortClassName);
-        $dir = $this->getClassDir($reflectionClass);
+        $dir = $this->getClassDir($classReflection);
         if ($dir === null) {
             return null;
         }

--- a/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenterStandalone.php
+++ b/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenterStandalone.php
@@ -8,7 +8,7 @@ use Efabrica\PHPStanLatte\LatteContext\LatteContext;
 use Efabrica\PHPStanLatte\LatteContext\Resolver\LatteContextResolverInterface;
 use Efabrica\PHPStanLatte\LatteContext\Resolver\Nette\NetteApplicationUIPresenterLatteContextResolver;
 use Efabrica\PHPStanLatte\LatteTemplateResolver\AbstractClassStandaloneTemplateResolver;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
+use PHPStan\Reflection\ClassReflection;
 use function count;
 use function dirname;
 use function is_dir;
@@ -23,14 +23,14 @@ final class NetteApplicationUIPresenterStandalone extends AbstractClassStandalon
         return ['Nette\Application\UI\Presenter'];
     }
 
-    protected function getClassContextResolver(ReflectionClass $reflectionClass, LatteContext $latteContext): LatteContextResolverInterface
+    protected function getClassContextResolver(ClassReflection $classReflection, LatteContext $latteContext): LatteContextResolverInterface
     {
-        return new NetteApplicationUIPresenterLatteContextResolver($reflectionClass, $latteContext);
+        return new NetteApplicationUIPresenterLatteContextResolver($classReflection, $latteContext);
     }
 
-    protected function getTemplatePathPatterns(ReflectionClass $reflectionClass, string $dir): array
+    protected function getTemplatePathPatterns(ClassReflection $classReflection, string $dir): array
     {
-        $shortClassName = $reflectionClass->getShortName();
+        $shortClassName = $classReflection->getNativeReflection()->getShortName();
         $presenterName = str_replace('Presenter', '', $shortClassName);
 
         return [
@@ -44,12 +44,12 @@ final class NetteApplicationUIPresenterStandalone extends AbstractClassStandalon
         return is_dir("$dir/templates") ? $dir : dirname($dir);
     }
 
-    protected function isStandaloneTemplate(ReflectionClass $reflectionClass, string $templateFile, array $matches): bool
+    protected function isStandaloneTemplate(ClassReflection $classReflection, string $templateFile, array $matches): bool
     {
         if (!is_string($matches[1])) {
             return false;
         }
         $action = $matches[1];
-        return count($this->getMethodsMatchingIncludingIgnored($reflectionClass, '/^(action|render)' . preg_quote($action) . '/')) === 0;
+        return count($this->getMethodsMatchingIncludingIgnored($classReflection, '/^(action|render)' . preg_quote($action) . '/')) === 0;
     }
 }

--- a/src/LinkProcessor/LinkParamsProcessor.php
+++ b/src/LinkProcessor/LinkParamsProcessor.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Efabrica\PHPStanLatte\LinkProcessor;
 
+use Efabrica\PHPStanLatte\Type\TypeHelper;
 use InvalidArgumentException;
 use LogicException;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
-use PHPStan\BetterReflection\BetterReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use function array_filter;
 use function array_flip;
 use function array_key_exists;
@@ -21,6 +24,13 @@ use function in_array;
 
 final class LinkParamsProcessor
 {
+    private ReflectionProvider $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
     /**
      * @param Arg[] $params
      * @return Arg[]
@@ -39,14 +49,21 @@ final class LinkParamsProcessor
             throw new InvalidArgumentException('Too many parameters');
         }
 
-        $reflectionClass = (new BetterReflection())->reflector()->reflectClass($class);
-        $reflectionMethod = $reflectionClass->getMethod($method);
-        if ($reflectionMethod === null) {
+        $classReflection = $this->reflectionProvider->getClass($class);
+        if (!$classReflection->hasNativeMethod($method)) {
             throw new InvalidArgumentException("Method $class::$method not found");
         }
 
+        $methodReflection = $classReflection->getNativeMethod($method);
+        $variants = $methodReflection->getVariants();
+        if ($variants === []) {
+            throw new InvalidArgumentException("Method $class::$method has no variants");
+        }
+
+        $parameters = $variants[0]->getParameters();
+
         $methodParameters = [];
-        foreach ($reflectionMethod->getParameters() as $param) {
+        foreach ($parameters as $param) {
             $methodParameters[] = $param->getName();
         }
 
@@ -74,21 +91,19 @@ final class LinkParamsProcessor
         }
 
         $i = 0;
-        foreach ($reflectionMethod->getParameters() as $param) {
+        foreach ($parameters as $param) {
             $name = $param->getName();
-            $type = (string) $param->getType();
+            $type = $param->getType();
+            $defaultValueType = $param->getDefaultValue();
             if (array_key_exists($i, $transferredParams)) {
                 $transferredParams[$name] = $transferredParams[$i];
                 unset($transferredParams[$i]);
                 $i++;
             } elseif (array_key_exists($name, $transferredParams)) {
                 continue;
-            } elseif ($param->isDefaultValueAvailable()) {
-                try {
-                    $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue($param->getDefaultValue()));
-                } catch (LogicException $e) {
-                }
-            } elseif ($type === 'array' || $type === 'iterable') {
+            } elseif ($defaultValueType !== null) {
+                $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue(TypeHelper::typeToValue($defaultValueType)));
+            } elseif ($type->isArray()->yes() || $type->isIterable()->yes()) {
                 $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue([]));
             } else {
                 $transferredParams[$name] = new Arg(BuilderHelpers::normalizeValue(null));
@@ -99,4 +114,5 @@ final class LinkParamsProcessor
             return $param instanceof Arg;
         });
     }
+
 }

--- a/src/LinkProcessor/LinkParamsProcessor.php
+++ b/src/LinkProcessor/LinkParamsProcessor.php
@@ -6,14 +6,11 @@ namespace Efabrica\PHPStanLatte\LinkProcessor;
 
 use Efabrica\PHPStanLatte\Type\TypeHelper;
 use InvalidArgumentException;
-use LogicException;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
-use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use function array_filter;
 use function array_flip;
@@ -114,5 +111,4 @@ final class LinkParamsProcessor
             return $param instanceof Arg;
         });
     }
-
 }

--- a/src/Resolver/ValueResolver/ValueResolver.php
+++ b/src/Resolver/ValueResolver/ValueResolver.php
@@ -93,6 +93,9 @@ final class ValueResolver
                     if ($options === null || count($options) !== 1) {
                         throw new ConstExprEvaluationException();
                     }
+                    if (!is_string($options[0])) {
+                        throw new ConstExprEvaluationException();
+                    }
                     $result[] = $options[0];
                 }
                 return implode('', $result);

--- a/src/Resolver/ValueResolver/ValueResolver.php
+++ b/src/Resolver/ValueResolver/ValueResolver.php
@@ -29,6 +29,7 @@ use function dirname;
 use function function_exists;
 use function implode;
 use function is_callable;
+use function is_string;
 use function method_exists;
 
 final class ValueResolver

--- a/src/Template/Form/Container.php
+++ b/src/Template/Form/Container.php
@@ -77,7 +77,7 @@ final class Container implements ControlHolderInterface, ControlInterface
     }
 
     /**
-     * @param array{name: string, type: string, controls: array<array{name: string}>} $data
+     * @param array{name: string, type: string, controls: array<array{name: string, class: class-string}>} $data
      */
     public static function fromJson(array $data, TypeStringResolver $typeStringResolver): self
     {

--- a/src/Type/TypeHelper.php
+++ b/src/Type/TypeHelper.php
@@ -106,7 +106,10 @@ final class TypeHelper
         return (new Printer())->print($type->toPhpDocNode());
     }
 
-    public static function typeToValue(?Type $type): mixed
+    /**
+     * @return mixed
+     */
+    public static function typeToValue(?Type $type)
     {
         if ($type === null) {
             return null;

--- a/src/Type/TypeHelper.php
+++ b/src/Type/TypeHelper.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Efabrica\PHPStanLatte\Type;
 
 use InvalidArgumentException;
+use LogicException;
+use PhpParser\BuilderHelpers;
+use PhpParser\Node\Expr;
 use PHPStan\PhpDocParser\Printer\Printer;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\ObjectType;
@@ -69,6 +73,22 @@ final class TypeHelper
         });
     }
 
+    /**
+     * @param ParametersAcceptor[] $variants
+     */
+    public static function getFirstParamTypeName(array $variants): ?string
+    {
+        if ($variants === []) {
+            return null;
+        }
+        $params = $variants[0]->getParameters();
+        if ($params === []) {
+            return null;
+        }
+        $classNames = $params[0]->getType()->getObjectClassNames();
+        return $classNames[0] ?? null;
+    }
+
     public static function serializeType(Type $type): string
     {
         $type = TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
@@ -85,5 +105,29 @@ final class TypeHelper
         });
 
         return (new Printer())->print($type->toPhpDocNode());
+    }
+
+    public static function typeToValue(?Type $type): mixed
+    {
+        if ($type === null) {
+            return null;
+        }
+
+        try {
+            if ($type->isConstantScalarValue()->yes()) {
+                $values = $type->getConstantScalarValues();
+                if (count($values) === 1) {
+                    return $values[0];
+                }
+            }
+
+            $constantArrays = $type->getConstantArrays();
+            if (count($constantArrays) === 1 && $constantArrays[0]->getKeyTypes() === []) {
+                return [];
+            }
+        } catch (LogicException) {
+        }
+
+        return null;
     }
 }

--- a/src/Type/TypeHelper.php
+++ b/src/Type/TypeHelper.php
@@ -6,8 +6,6 @@ namespace Efabrica\PHPStanLatte\Type;
 
 use InvalidArgumentException;
 use LogicException;
-use PhpParser\BuilderHelpers;
-use PhpParser\Node\Expr;
 use PHPStan\PhpDocParser\Printer\Printer;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Type\ErrorType;
@@ -16,6 +14,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
+use function count;
 
 final class TypeHelper
 {
@@ -125,7 +124,7 @@ final class TypeHelper
             if (count($constantArrays) === 1 && $constantArrays[0]->getKeyTypes() === []) {
                 return [];
             }
-        } catch (LogicException) {
+        } catch (LogicException $e) {
         }
 
         return null;

--- a/tests/Rule/LatteTemplatesRule/CustomLatteTemplateResolver/Fixtures/TestingCustomClassTemplateResolver.php
+++ b/tests/Rule/LatteTemplatesRule/CustomLatteTemplateResolver/Fixtures/TestingCustomClassTemplateResolver.php
@@ -11,7 +11,7 @@ use Efabrica\PHPStanLatte\Template\Template;
 use Efabrica\PHPStanLatte\Template\TemplateContext;
 use Efabrica\PHPStanLatte\Template\Variable;
 use Nette\Application\UI\Control;
-use PHPStan\BetterReflection\Reflection\ReflectionClass;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\StringType;
 use function dirname;
 
@@ -27,11 +27,11 @@ final class TestingCustomClassTemplateResolver extends AbstractClassTemplateReso
         return '/.*Control/';
     }
 
-    protected function getClassResult(ReflectionClass $resolveClass, LatteContext $latteContext): LatteTemplateResolverResult
+    protected function getClassResult(ClassReflection $classReflection, LatteContext $latteContext): LatteTemplateResolverResult
     {
         $result = new LatteTemplateResolverResult();
         $result->addTemplate(new Template(
-            dirname($resolveClass->getFileName()) . '/templates/default.latte',
+            dirname($classReflection->getFileName()) . '/templates/default.latte',
             Control::class,
             'resolved',
             new TemplateContext(

--- a/tests/Rule/LatteTemplatesRule/LatteTemplatesRuleTest.php
+++ b/tests/Rule/LatteTemplatesRule/LatteTemplatesRuleTest.php
@@ -58,7 +58,10 @@ abstract class LatteTemplatesRuleTest extends RuleTestCase
             if ($line === null) {
                 $line = -1;
             }
-            return $strictlyTypedSprintf($line, $error->getMessage(), pathinfo($error->getFile(), PATHINFO_BASENAME), $error->getTip());
+            $message = $error->getMessage();
+            // bug in PHPStan meessage
+            $message = str_replace('method static method', 'static method', $message);
+            return $strictlyTypedSprintf($line, $message, pathinfo($error->getFile(), PATHINFO_BASENAME), $error->getTip());
         }, $actualErrors);
         sort($actualErrors);
         sort($expectedErrors);


### PR DESCRIPTION
Last version of PHPStan breaks direct use o BetterRefection causing reflection exceptions.

I rewrited code to avoid BetterReflection completely and use only PHPStan reflections - which is correct way we should used from start anyway.

It is BC break for users using custom resolvers because signature of some methods changed. But fix should be staraighforward.