### PR TITLE
Support the dir structure with templates in the same dir as the presenter

### DIFF
--- a/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
+++ b/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
@@ -216,6 +216,7 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
         $dir = is_dir($dir . DIRECTORY_SEPARATOR . 'templates') ? $dir : dirname($dir);
 
         $templateFileCandidates = [
+            $dir . DIRECTORY_SEPARATOR . $presenterName . DIRECTORY_SEPARATOR . $actionName . '.latte',
             $dir . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $presenterName . DIRECTORY_SEPARATOR . $actionName . '.latte',
             $dir . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $presenterName . '.' . $actionName . '.latte',
         ];

--- a/src/LinkProcessor/FakePresenterFactory.php
+++ b/src/LinkProcessor/FakePresenterFactory.php
@@ -26,7 +26,7 @@ final class FakePresenterFactory extends PresenterFactory
         parent::setMapping($mapping);
         foreach ($mapping as $module => $mask) {
             if (is_string($mask)) {
-                if (!preg_match('#^\\\\?([\w\\\\]*\\\\)?(\w*\*\w*?\\\\)?([\w\\\\]*\*\w*)$#D', $mask, $m)) {
+                if (!preg_match('#^\\\\?([\w\\\\]*\\\\)?(\w*\*\w*?\\\\)?([\w\\\\]*\*\*?\w*)$#D', $mask, $m)) {
                     throw new InvalidStateException("Invalid mapping mask '$mask'.");
                 }
 


### PR DESCRIPTION
When using mapping like:

```
App\Presentation\*\**Presenter
```

As described in https://doc.nette.org/cs/application/directory-structure#toc-mapovani-presenteru