### PR TITLE
PHPStan validates identifiers and action names like `foo(bar)` do not pass

### DIFF
--- a/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
+++ b/src/LatteTemplateResolver/Nette/NetteApplicationUIPresenter.php
@@ -159,8 +159,7 @@ final class NetteApplicationUIPresenter extends AbstractClassTemplateResolver
                     $result->addErrorFromBuilder(RuleErrorBuilder::message("Cannot resolve latte template for action $actionName")
                         ->identifier('latte.cannotResolve')
                         ->file($classReflection->getFileName() ?? 'unknown')
-                        ->line($actionDefinition['line'])
-                        ->identifier($actionName));
+                        ->line($actionDefinition['line']));
                 }
                 continue;
             }


### PR DESCRIPTION
This ~~is~~was also the second `identifier()` call on the same `$result` which overwrites the first one.